### PR TITLE
clean up repetition, fix retry logic, and add SchemaInput flexibilityFix/code repeatation

### DIFF
--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -1,12 +1,10 @@
-import { z } from "zod";
-import type { ShapecraftModel } from "../types.js";
+import type { SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
 
 export interface AnthropicBackendOptions {
   model?: string;
   apiKey?: string;
-  maxRetries?: number;
 }
 
 export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftModel {
@@ -16,8 +14,7 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
     id: `anthropic:${modelId}`,
     guaranteeLevel: "best-effort",
 
-    async generate<T>(prompt: string, schema: z.ZodType<any>): Promise<T> {
-      // dynamic import avoids hard dependency — user must install @anthropic-ai/sdk
+    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mod: any = await import("@anthropic-ai/sdk").catch(() => {
         throw new Error("Install sdk: npm install @anthropic-ai/sdk");

--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ShapecraftModel } from "../types.js";
-import { SchemaViolationError } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
+import { parseAndValidate } from "../core/parse.js";
 
 export interface AnthropicBackendOptions {
   model?: string;
@@ -40,15 +40,7 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
       const raw: string =
         response.content[0]?.type === "text" ? response.content[0].text : "";
 
-      try {
-        const jsonMatch = raw.match(/\{[\s\S]*\}|\[[\s\S]*\]/);
-        const parsed = JSON.parse(jsonMatch?.[0] ?? raw);
-        const result = schema.safeParse(parsed);
-        if (!result.success) throw new SchemaViolationError(raw, result.error);
-        return result.data as T;
-      } catch (err) {
-        throw new SchemaViolationError(raw, err);
-      }
+      return parseAndValidate<T>(raw, schema, { extractJson: true });
     },
   };
 }

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -1,5 +1,4 @@
-import { z } from "zod";
-import type { ShapecraftModel } from "../types.js";
+import type { SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
 
@@ -15,7 +14,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
     id: `groq:${modelId}`,
     guaranteeLevel: "native",
 
-    async generate<T>(prompt: string, schema: z.ZodType<any>): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mod: any = await import("groq-sdk").catch(() => {
         throw new Error("Install groq: npm install groq-sdk");

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ShapecraftModel } from "../types.js";
-import { SchemaViolationError } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
+import { parseAndValidate } from "../core/parse.js";
 
 export interface GroqBackendOptions {
   model?: string;
@@ -39,14 +39,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
 
       const raw: string = response.choices[0]?.message?.content ?? "";
 
-      try {
-        const parsed = JSON.parse(raw);
-        const result = schema.safeParse(parsed);
-        if (!result.success) throw new SchemaViolationError(raw, result.error);
-        return result.data as T;
-      } catch (err) {
-        throw new SchemaViolationError(raw, err);
-      }
+      return parseAndValidate<T>(raw, schema);
     },
   };
 }

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -1,0 +1,4 @@
+export { openai } from "./openai.js";
+export { ollama } from "./ollama.js";
+export { anthropic } from "./anthropic.js";
+export { groq } from "./groq.js";

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ShapecraftModel } from "../types.js";
-import { SchemaViolationError } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { parseAndValidate } from "../core/parse.js";
 
 export interface OllamaBackendOptions {
   model: string;
@@ -40,14 +40,7 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
       const json = await response.json() as { message?: { content?: string } };
       const raw = json.message?.content ?? "";
 
-      try {
-        const parsed = JSON.parse(raw);
-        const result = schema.safeParse(parsed);
-        if (!result.success) throw new SchemaViolationError(raw, result.error);
-        return result.data as T;
-      } catch (err) {
-        throw new SchemaViolationError(raw, err);
-      }
+      return parseAndValidate<T>(raw, schema);
     },
   };
 }

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
-import type { ShapecraftModel } from "../types.js";
+import type { SchemaInput, ShapecraftModel } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { isZodSchema } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
 
 export interface OllamaBackendOptions {
@@ -15,9 +16,16 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
     id: `ollama:${options.model}`,
     guaranteeLevel: "constrained",
 
-    async generate<T>(prompt: string, schema: z.ZodType<any>): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
       const { system, user } = buildStructuredPrompt(prompt, schema);
-      const jsonSchema = toJsonSchema(schema);
+
+      // Pass JSON schema to Ollama's format param for constrained decoding when possible
+      let format: unknown = undefined;
+      if (isZodSchema(schema)) {
+        format = toJsonSchema(schema as z.ZodType<any>);
+      } else if ("jsonSchema" in (schema as object)) {
+        format = (schema as { jsonSchema: Record<string, unknown> }).jsonSchema;
+      }
 
       const response = await fetch(`${host}/api/chat`, {
         method: "POST",
@@ -28,7 +36,7 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
             { role: "system", content: system },
             { role: "user", content: user },
           ],
-          format: jsonSchema,
+          ...(format ? { format } : {}),
           stream: false,
         }),
       });

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
-import type { ShapecraftModel } from "../types.js";
+import type { SchemaInput, ShapecraftModel } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { isZodSchema } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
 
 export interface OpenAIBackendOptions {
@@ -16,7 +17,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
     id: `openai:${modelId}`,
     guaranteeLevel: "native",
 
-    async generate<T>(prompt: string, schema: z.ZodType<any>): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mod: any = await import("openai").catch(() => {
         throw new Error("Install openai: npm install openai");
@@ -29,7 +30,19 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
       });
 
       const { system, user } = buildStructuredPrompt(prompt, schema);
-      const jsonSchema = toJsonSchema(schema);
+
+      // Use strict json_schema mode for Zod, non-strict for raw jsonSchema, json_object otherwise
+      const responseFormat = isZodSchema(schema)
+        ? {
+            type: "json_schema" as const,
+            json_schema: { name: "output", strict: true, schema: toJsonSchema(schema as z.ZodType<any>) },
+          }
+        : "jsonSchema" in (schema as object)
+          ? {
+              type: "json_schema" as const,
+              json_schema: { name: "output", strict: false, schema: (schema as { jsonSchema: Record<string, unknown> }).jsonSchema },
+            }
+          : { type: "json_object" as const };
 
       const response = await client.chat.completions.create({
         model: modelId,
@@ -37,14 +50,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
           { role: "system", content: system },
           { role: "user", content: user },
         ],
-        response_format: {
-          type: "json_schema",
-          json_schema: {
-            name: "output",
-            strict: true,
-            schema: jsonSchema,
-          },
-        },
+        response_format: responseFormat,
       });
 
       const raw: string = response.choices[0]?.message?.content ?? "";

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ShapecraftModel } from "../types.js";
-import { SchemaViolationError } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { parseAndValidate } from "../core/parse.js";
 
 export interface OpenAIBackendOptions {
   model?: string;
@@ -49,14 +49,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
 
       const raw: string = response.choices[0]?.message?.content ?? "";
 
-      try {
-        const parsed = JSON.parse(raw);
-        const result = schema.safeParse(parsed);
-        if (!result.success) throw new SchemaViolationError(raw, result.error);
-        return result.data as T;
-      } catch (err) {
-        throw new SchemaViolationError(raw, err);
-      }
+      return parseAndValidate<T>(raw, schema);
     },
   };
 }

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { GenerateOptions, GenerateResult, ShapecraftModel } from "../types.js";
-import { MaxRetriesExceededError } from "../types.js";
+import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
 
 export async function generate<T>(
   model: ShapecraftModel,
@@ -20,6 +20,7 @@ export async function generate<T>(
         attempts: attempt,
       };
     } catch (err) {
+      if (!(err instanceof SchemaViolationError)) throw err;
       if (attempt === maxRetries) break;
     }
   }

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -1,11 +1,10 @@
-import { z } from "zod";
-import type { GenerateOptions, GenerateResult, ShapecraftModel } from "../types.js";
+import type { GenerateOptions, GenerateResult, SchemaInput, ShapecraftModel } from "../types.js";
 import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
+import { validateOutput } from "./validate.js";
 
 export async function generate<T>(
   model: ShapecraftModel,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  schema: z.ZodType<any>,
+  schema: SchemaInput<T>,
   prompt: string,
   options: GenerateOptions = {}
 ): Promise<GenerateResult<T>> {
@@ -13,7 +12,8 @@ export async function generate<T>(
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const data = await model.generate<T>(prompt, schema);
+      const raw = await model.generate<T>(prompt, schema);
+      const data = validateOutput<T>(raw, schema);
       return {
         data,
         guaranteeLevel: model.guaranteeLevel,

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -1,20 +1,29 @@
-import { z } from "zod";
+import type { SchemaInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
+import { isZodSchema } from "./validate.js";
 
 export function parseAndValidate<T>(
   raw: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  schema: z.ZodType<any>,
+  schema: SchemaInput<T>,
   opts: { extractJson?: boolean } = {}
 ): T {
+  // Pattern schemas return the raw string directly — no JSON parsing
+  if ("pattern" in (schema as object)) return raw as T;
+
   try {
     const text = opts.extractJson
       ? (raw.match(/\{[\s\S]*\}|\[[\s\S]*\]/)?.[0] ?? raw)
       : raw;
     const parsed = JSON.parse(text);
-    const result = schema.safeParse(parsed);
-    if (!result.success) throw new SchemaViolationError(raw, result.error);
-    return result.data as T;
+
+    if (isZodSchema(schema)) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const result = (schema as any).safeParse(parsed);
+      if (!result.success) throw new SchemaViolationError(raw, result.error);
+      return result.data as T;
+    }
+
+    return parsed as T;
   } catch (err) {
     if (err instanceof SchemaViolationError) throw err;
     throw new SchemaViolationError(raw, err);

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -1,0 +1,22 @@
+import { z } from "zod";
+import { SchemaViolationError } from "../types.js";
+
+export function parseAndValidate<T>(
+  raw: string,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  schema: z.ZodType<any>,
+  opts: { extractJson?: boolean } = {}
+): T {
+  try {
+    const text = opts.extractJson
+      ? (raw.match(/\{[\s\S]*\}|\[[\s\S]*\]/)?.[0] ?? raw)
+      : raw;
+    const parsed = JSON.parse(text);
+    const result = schema.safeParse(parsed);
+    if (!result.success) throw new SchemaViolationError(raw, result.error);
+    return result.data as T;
+  } catch (err) {
+    if (err instanceof SchemaViolationError) throw err;
+    throw new SchemaViolationError(raw, err);
+  }
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import type { SchemaInput } from "../types.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toJsonSchema(schema: z.ZodType<any>): Record<string, unknown> {
@@ -7,20 +8,26 @@ export function toJsonSchema(schema: z.ZodType<any>): Record<string, unknown> {
   return zodToJsonSchema(schema as any, { target: "openApi3" }) as Record<string, unknown>;
 }
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function buildStructuredPrompt(
   prompt: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  schema: z.ZodType<any>,
+  schema: SchemaInput,
   systemPrompt?: string
 ): { system: string; user: string } {
-  const jsonSchema = JSON.stringify(toJsonSchema(schema), null, 2);
+  let schemaInfo: string;
+
+  if (schema instanceof z.ZodType) {
+    schemaInfo = `Respond with valid JSON matching this schema exactly:\n\n${JSON.stringify(toJsonSchema(schema), null, 2)}`;
+  } else if ("jsonSchema" in schema) {
+    schemaInfo = `Respond with valid JSON matching this schema exactly:\n\n${JSON.stringify(schema.jsonSchema, null, 2)}`;
+  } else if ("pattern" in schema) {
+    schemaInfo = `Respond with a plain string matching this pattern: ${schema.pattern}`;
+  } else {
+    schemaInfo = "Respond with valid output as required.";
+  }
+
   const system =
     systemPrompt ??
-    `You are a precise assistant. Always respond with valid JSON matching the schema exactly. No extra text, no markdown, no explanation.
-
-Schema:
-${jsonSchema}`;
+    `You are a precise assistant. ${schemaInfo} No extra text, no markdown, no explanation.`;
 
   return { system, user: prompt };
 }

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,0 +1,78 @@
+import { z } from "zod";
+import type { SchemaInput } from "../types.js";
+import { SchemaViolationError } from "../types.js";
+
+export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
+  return schema instanceof z.ZodType;
+}
+
+function checkJsonSchema(value: unknown, schema: Record<string, unknown>): void {
+  const type = schema.type as string | undefined;
+
+  if (type) {
+    const actual = Array.isArray(value) ? "array" : value === null ? "null" : typeof value;
+    if (actual !== type) {
+      throw new Error(`Expected type "${type}", got "${actual}"`);
+    }
+  }
+
+  if (schema.enum) {
+    if (!(schema.enum as unknown[]).includes(value)) {
+      throw new Error(`Value not in enum: ${JSON.stringify(value)}`);
+    }
+  }
+
+  if (typeof value === "object" && value !== null && !Array.isArray(value) && schema.properties) {
+    const obj = value as Record<string, unknown>;
+    const required = (schema.required as string[]) ?? [];
+    const properties = schema.properties as Record<string, Record<string, unknown>>;
+
+    for (const key of required) {
+      if (!(key in obj)) throw new Error(`Missing required property: "${key}"`);
+    }
+
+    for (const [key, propSchema] of Object.entries(properties)) {
+      if (key in obj) checkJsonSchema(obj[key], propSchema);
+    }
+  }
+
+  if (Array.isArray(value) && schema.items) {
+    for (const item of value) {
+      checkJsonSchema(item, schema.items as Record<string, unknown>);
+    }
+  }
+}
+
+export function validateOutput<T>(output: unknown, schema: SchemaInput<T>): T {
+  if (isZodSchema(schema)) {
+    const result = schema.safeParse(output);
+    if (!result.success) throw new SchemaViolationError(JSON.stringify(output), result.error);
+    return result.data;
+  }
+
+  if ("jsonSchema" in schema) {
+    try {
+      checkJsonSchema(output, schema.jsonSchema);
+    } catch (err) {
+      throw new SchemaViolationError(JSON.stringify(output), err);
+    }
+    return output as T;
+  }
+
+  if ("pattern" in schema) {
+    const str = typeof output === "string" ? output : JSON.stringify(output);
+    if (!schema.pattern.test(str)) {
+      throw new SchemaViolationError(str, `Output does not match pattern ${schema.pattern}`);
+    }
+    return output as T;
+  }
+
+  if ("validate" in schema) {
+    if (!schema.validate(output)) {
+      throw new SchemaViolationError(JSON.stringify(output), "Custom validator returned false");
+    }
+    return output as T;
+  }
+
+  throw new Error("Unknown schema type");
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,7 @@
 export { generate } from "./core/generate.js";
 export { toJsonSchema, buildStructuredPrompt } from "./core/schema.js";
 
-export { openai } from "./backends/openai.js";
-export { ollama } from "./backends/ollama.js";
-export { anthropic } from "./backends/anthropic.js";
-export { groq } from "./backends/groq.js";
+export * from "./backends/index.js";
 
 export type {
   ShapecraftModel,

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,11 +2,16 @@ import { z } from "zod";
 
 export type GuaranteeLevel = "constrained" | "native" | "best-effort";
 
+export type JsonSchemaInput = { jsonSchema: Record<string, unknown> };
+export type PatternInput = { pattern: RegExp };
+export type ValidatorInput = { validate: (output: unknown) => boolean };
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput;
+
 export interface ShapecraftModel {
   id: string;
   guaranteeLevel: GuaranteeLevel;
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  generate<T>(prompt: string, schema: z.ZodType<any>): Promise<T>;
+  generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T>;
 }
 
 export interface GenerateOptions {

--- a/tests/Schema-Flexibility.test.ts
+++ b/tests/Schema-Flexibility.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { generate } from "../src/core/generate.js";
+import { SchemaViolationError, MaxRetriesExceededError } from "../src/types.js";
+import type { ShapecraftModel } from "../src/types.js";
+import { mockModel } from "./helpers/index.js";
+
+// ─── Raw JSON Schema ──────────────────────────────────────────────────────────
+
+describe("Schema Flexibility — Raw JSON Schema input", () => {
+  const rawSchema = {
+    type: "object",
+    properties: {
+      name: { type: "string" },
+      age: { type: "number" },
+    },
+    required: ["name", "age"],
+  };
+
+  it("returns data when output matches raw JSON schema", async () => {
+    const model = mockModel({ name: "Alice", age: 30 });
+    const result = await generate(model, { jsonSchema: rawSchema }, "get person");
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+    expect(result.attempts).toBe(1);
+  });
+
+  it("throws MaxRetriesExceededError when output fails raw JSON schema validation", async () => {
+    const model = mockModel({ name: 123, age: "wrong" });
+    await expect(
+      generate(model, { jsonSchema: rawSchema }, "get person", { maxRetries: 2 })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("retries on failure before succeeding", async () => {
+    let calls = 0;
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        calls++;
+        if (calls < 3) throw new SchemaViolationError("bad", "invalid");
+        return { name: "Alice", age: 30 } as T;
+      },
+    };
+    const result = await generate(model, { jsonSchema: rawSchema }, "get person", { maxRetries: 3 });
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+    expect(result.attempts).toBe(3);
+  });
+});
+
+// ─── Regex Pattern ────────────────────────────────────────────────────────────
+
+describe("Schema Flexibility — Regex pattern constraint", () => {
+  const datePattern = /^\d{4}-\d{2}-\d{2}$/;
+
+  it("returns data when output matches regex pattern", async () => {
+    const model = mockModel("2024-06-25");
+    const result = await generate(model, { pattern: datePattern }, "get a date");
+    expect(result.data).toBe("2024-06-25");
+  });
+
+  it("throws MaxRetriesExceededError when output does not match pattern", async () => {
+    const model = mockModel("not-a-date");
+    await expect(
+      generate(model, { pattern: datePattern }, "get a date", { maxRetries: 2 })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("accepts any string matching a simple pattern", async () => {
+    const model = mockModel("abc123");
+    const result = await generate(model, { pattern: /^[a-z]+\d+$/ }, "get alphanumeric");
+    expect(result.data).toBe("abc123");
+  });
+});
+
+// ─── Custom Validator ─────────────────────────────────────────────────────────
+
+describe("Schema Flexibility — Custom validator function", () => {
+  it("returns data when custom validator returns true", async () => {
+    const model = mockModel({ id: "abc", value: 42 });
+    const result = await generate(
+      model,
+      { validate: (x: unknown) => typeof (x as any).id === "string" },
+      "get object with id"
+    );
+    expect((result.data as any).id).toBe("abc");
+  });
+
+  it("throws MaxRetriesExceededError when custom validator returns false", async () => {
+    const model = mockModel({ value: 42 });
+    await expect(
+      generate(
+        model,
+        { validate: (x: unknown) => (x as any).id !== undefined },
+        "get object with id",
+        { maxRetries: 2 }
+      )
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("passes the raw output to the validator", async () => {
+    const seen: unknown[] = [];
+    const model = mockModel([1, 2, 3]);
+    await generate(
+      model,
+      {
+        validate: (x: unknown) => {
+          seen.push(x);
+          return Array.isArray(x) && (x as number[]).length === 3;
+        },
+      },
+      "get array"
+    );
+    expect(seen[0]).toEqual([1, 2, 3]);
+  });
+});

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -1,24 +1,13 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect } from "vitest";
 import { z } from "zod";
 import { generate } from "../src/core/generate.js";
-import type { ShapecraftModel } from "../src/types.js";
-import { SchemaViolationError } from "../src/types.js";
+import { anthropic } from "../src/backends/anthropic.js";
+import { mockModel } from "./helpers/index.js";
 
 const PersonSchema = z.object({
   name: z.string(),
   age: z.number(),
 });
-
-function mockModel(returnValue: unknown, shouldFail = false): ShapecraftModel {
-  return {
-    id: "mock:test",
-    guaranteeLevel: "constrained",
-    async generate<T>(): Promise<T> {
-      if (shouldFail) throw new SchemaViolationError("bad", "invalid");
-      return returnValue as T;
-    },
-  };
-}
 
 describe("generate", () => {
   it("returns data on success", async () => {
@@ -29,11 +18,36 @@ describe("generate", () => {
     expect(result.guaranteeLevel).toBe("constrained");
   });
 
-  it("retries on failure and throws MaxRetriesExceededError", async () => {
+  it("retries on SchemaViolationError and throws MaxRetriesExceededError", async () => {
     const model = mockModel(null, true);
     const { MaxRetriesExceededError } = await import("../src/types.js");
     await expect(
       generate(model, PersonSchema, "get person", { maxRetries: 2 })
     ).rejects.toBeInstanceOf(MaxRetriesExceededError);
   });
+
+  it("re-throws non-schema errors immediately without retrying", async () => {
+    let calls = 0;
+    const model = {
+      id: "mock:test",
+      guaranteeLevel: "constrained" as const,
+      async generate<T>(): Promise<T> {
+        calls++;
+        throw new Error("network failure");
+      },
+    };
+    await expect(
+      generate(model, PersonSchema, "get person", { maxRetries: 3 })
+    ).rejects.toThrow("network failure");
+    expect(calls).toBe(1);
+  });
+});
+
+describe("anthropic integration", () => {
+  it("returns structured data from real API", async () => {
+    const model = anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: "claude-haiku-4-5-20251001" });
+    const result = await generate(model, PersonSchema, "Alice is 30 years old");
+    expect(result.data).toMatchObject({ name: expect.any(String), age: expect.any(Number) });
+    expect(result.guaranteeLevel).toBe("best-effort");
+  }, 30000);
 });

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { z } from "zod";
 import { generate } from "../src/core/generate.js";
 import { anthropic } from "../src/backends/anthropic.js";
@@ -43,11 +43,27 @@ describe("generate", () => {
   });
 });
 
-describe.skipIf(!process.env.ANTHROPIC_API_KEY)("anthropic integration", () => {
-  it("returns structured data from real API", async () => {
-    const model = anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: "claude-haiku-4-5-20251001" });
+describe("anthropic integration", () => {
+  beforeEach(() => {
+    vi.mock("@anthropic-ai/sdk", () => ({
+      default: class {
+        messages = {
+          create: vi.fn().mockResolvedValue({
+            content: [{ type: "text", text: '{"name":"Alice","age":30}' }],
+          }),
+        };
+      },
+    }));
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("returns structured data", async () => {
+    const model = anthropic({ apiKey: "mock-key", model: "claude-haiku-4-5-20251001" });
     const result = await generate(model, PersonSchema, "Alice is 30 years old");
     expect(result.data).toMatchObject({ name: expect.any(String), age: expect.any(Number) });
     expect(result.guaranteeLevel).toBe("best-effort");
-  }, 30000);
+  });
 });

--- a/tests/generate.test.ts
+++ b/tests/generate.test.ts
@@ -43,7 +43,7 @@ describe("generate", () => {
   });
 });
 
-describe("anthropic integration", () => {
+describe.skipIf(!process.env.ANTHROPIC_API_KEY)("anthropic integration", () => {
   it("returns structured data from real API", async () => {
     const model = anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: "claude-haiku-4-5-20251001" });
     const result = await generate(model, PersonSchema, "Alice is 30 years old");

--- a/tests/helpers/index.ts
+++ b/tests/helpers/index.ts
@@ -1,0 +1,23 @@
+import type { ShapecraftModel } from "../../src/types.js";
+import { SchemaViolationError } from "../../src/types.js";
+
+export function mockModel(returnValue: unknown, shouldFail = false): ShapecraftModel {
+  return {
+    id: "mock:test",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      if (shouldFail) throw new SchemaViolationError("bad", "invalid");
+      return returnValue as T;
+    },
+  };
+}
+
+export function mockModelThatFails(): ShapecraftModel {
+  return {
+    id: "mock:test",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      throw new SchemaViolationError("bad output", "invalid");
+    },
+  };
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2020"],
+    "types": ["node"],
     "strict": true,
     "exactOptionalPropertyTypes": true,
     "declaration": true,

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,27 @@
+import { defineConfig } from "vitest/config";
+import { readFileSync } from "fs";
+
+function loadDotEnv(): Record<string, string> {
+  try {
+    return Object.fromEntries(
+      readFileSync(".env", "utf-8")
+        .split("\n")
+        .filter((line) => line.trim() && !line.startsWith("#"))
+        .map((line) => {
+          const idx = line.indexOf("=");
+          const key = line.slice(0, idx).trim();
+          const val = line.slice(idx + 1).trim().replace(/^["']|["']$/g, "");
+          return [key, val];
+        })
+        .filter(([k]) => k)
+    );
+  } catch {
+    return {};
+  }
+}
+
+export default defineConfig({
+  test: {
+    env: loadDotEnv(),
+  },
+});


### PR DESCRIPTION
- Fixes a bug where all errors (network, auth) were retried — now only SchemaViolationError triggers retry
- Extracts shared parseAndValidat helper to eliminate duplicated JSON-parse/validate blocks across all four backends
- Adds SchemaInput<T> union type supporting Zod, raw JSON Schema, regex patterns, and custom validators alongside a central validateOutput dispatcher
- Adds test infrastructure (tests/helpers/), a full Schma Flexibility test suite (9 tests), and a backends barrel export (src/backends/index.ts)