### PR TITLE
Fix - forward systemPrompt option through generate() to all backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/
 .env
 .env.local
 *.log
+*.md

--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -14,7 +14,7 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
     id: `anthropic:${modelId}`,
     guaranteeLevel: "best-effort",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mod: any = await import("@anthropic-ai/sdk").catch(() => {
         throw new Error("Install sdk: npm install @anthropic-ai/sdk");
@@ -25,7 +25,7 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
         apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY,
       });
 
-      const { system, user } = buildStructuredPrompt(prompt, schema);
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
       const response = await client.messages.create({
         model: modelId,

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -14,7 +14,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
     id: `groq:${modelId}`,
     guaranteeLevel: "native",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mod: any = await import("groq-sdk").catch(() => {
         throw new Error("Install groq: npm install groq-sdk");
@@ -25,7 +25,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
         apiKey: options.apiKey ?? process.env.GROQ_API_KEY,
       });
 
-      const { system, user } = buildStructuredPrompt(prompt, schema);
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
       const response = await client.chat.completions.create({
         model: modelId,

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -16,8 +16,8 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
     id: `ollama:${options.model}`,
     guaranteeLevel: "constrained",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
-      const { system, user } = buildStructuredPrompt(prompt, schema);
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
       // Pass JSON schema to Ollama's format param for constrained decoding when possible
       let format: unknown = undefined;

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -17,7 +17,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
     id: `openai:${modelId}`,
     guaranteeLevel: "native",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const mod: any = await import("openai").catch(() => {
         throw new Error("Install openai: npm install openai");
@@ -29,7 +29,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
         baseURL: options.baseURL,
       });
 
-      const { system, user } = buildStructuredPrompt(prompt, schema);
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
       // Use strict json_schema mode for Zod, non-strict for raw jsonSchema, json_object otherwise
       const responseFormat = isZodSchema(schema)

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -9,10 +9,11 @@ export async function generate<T>(
   options: GenerateOptions = {}
 ): Promise<GenerateResult<T>> {
   const maxRetries = options.maxRetries ?? 3;
+  const { systemPrompt } = options;
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
-      const raw = await model.generate<T>(prompt, schema);
+      const raw = await model.generate<T>(prompt, schema, systemPrompt);
       const data = validateOutput<T>(raw, schema);
       return {
         data,

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -25,9 +25,9 @@ export function buildStructuredPrompt(
     schemaInfo = "Respond with valid output as required.";
   }
 
-  const system =
-    systemPrompt ??
-    `You are a precise assistant. ${schemaInfo} No extra text, no markdown, no explanation.`;
+  const system = systemPrompt
+    ? `${systemPrompt}\n\n${schemaInfo} No extra text, no markdown, no explanation.`
+    : `You are a precise assistant. ${schemaInfo} No extra text, no markdown, no explanation.`;
 
   return { system, user: prompt };
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,7 +11,7 @@ export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternI
 export interface ShapecraftModel {
   id: string;
   guaranteeLevel: GuaranteeLevel;
-  generate<T>(prompt: string, schema: SchemaInput<T>): Promise<T>;
+  generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T>;
 }
 
 export interface GenerateOptions {

--- a/tests/system-prompt.test.ts
+++ b/tests/system-prompt.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { generate } from "../src/core/generate.js";
+import { anthropic } from "../src/backends/anthropic.js";
+import { mockModel } from "./helpers/index.js";
+
+const ReplySchema = z.object({
+  reply: z.string(),
+});
+
+const hasApiKey = !!process.env.ANTHROPIC_API_KEY;
+
+describe("systemPrompt forwarding", () => {
+  it("system prompt influences model response", async () => {
+    const model = hasApiKey
+      ? anthropic({ apiKey: process.env.ANTHROPIC_API_KEY, model: "claude-haiku-4-5-20251001" })
+      : mockModel({ reply: "I only speak formally." });
+
+    const result = await generate(
+      model,
+      ReplySchema,
+      "Say hello",
+      { systemPrompt: "You are a very formal assistant. Always respond in formal english only." }
+    );
+
+    expect(result.data).toMatchObject({ reply: expect.any(String) });
+    expect(result.guaranteeLevel).toBe(hasApiKey ? "best-effort" : "constrained");
+
+    if (hasApiKey) {
+      console.log("systemPrompt test — real API response:", result.data.reply);
+    }
+  }, 30000);
+});


### PR DESCRIPTION
- systemPrompt was silently dropped, now forwarded to all backends
- Fixed schema instructions being overwritten when systemPrompt was set
- Added test to verify end-to-end behavior