### PR TITLE
feat: add XML output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,11 +89,9 @@ const result = await generate(model, {
 
 ### XML
 
-You provide an example XML template with `{string}` / `{number}` / `{boolean}`
-placeholders — the model fills it in. By default `result.data` is the **validated
-XML string** (the format you asked for); add `parse: true` to get a parsed JS
-object instead. Either way the output is validated as well-formed XML, and any
-`required` nodes must be present and non-empty or the call retries.
+You provide an example XML template — the model fills it in. By default
+`result.data` is the **validated XML string** (the format you asked for); add
+`parse: true` to get a parsed JS object instead.
 
 ```typescript
 const result = await generate(model, {
@@ -107,21 +105,112 @@ console.log(result.data);
 // "<book>\n  <title>Clean Code</title>\n  <author>Robert C. Martin</author>\n  <year>2008</year>\n</book>"
 ```
 
-Anything you write in the template is reproduced verbatim — including
-**attributes** and **namespaces**, which fall out for free:
+#### Template rules
+
+**1. Only `{string}`, `{number}`, `{boolean}` are valid inside `{}`.**
+Anything else wrapped in braces throws before the model is ever called — a
+typo'd placeholder is a template bug, not something worth retrying.
+
+```typescript
+import { xmlType } from "@aviasole/shapecraft";
+
+xml: { template: `<book edition="${xmlType.string}">...` }   // ✅ fine
+xml: { template: `<book edition="{strng}">...` }             // ❌ throws immediately:
+// "Invalid placeholder(s) in xml.template: {strng}. Only {string}, {number},
+//  and {boolean} are recognized (see xmlType)."
+```
+
+**2. Text with no `{}` at all is a literal — reproduced as-is, best-effort.**
+The model is instructed to leave it untouched, and usually does. But text that
+*reads* like an instruction (a description, a placeholder-shaped phrase) can
+still get "helpfully" rewritten by the model — that's an LLM judgment call, not
+something a validator can catch, since there's no syntax marking it special.
+
+```typescript
+xml: { template: `<book status="in-stock">...` }
+// "in-stock" is fixed content — usually passed through unchanged
+```
+
+If a value must be **guaranteed** unchanged, use `enforceLiterals` (below) — or
+better, leave it out of the template entirely and splice it into
+`result.data` yourself after `generate()` returns.
+
+**3. Attributes follow the same two rules as element text.**
+`{string}`/`{number}`/`{boolean}` in an attribute gets filled in; anything else
+is a literal.
+
+```typescript
+xml: {
+  template: `<book id="{string}" available="{boolean}">\n  <title lang="{string}">{string}</title>\n</book>`,
+}
+// result.data → '<book id="978-1-4920-5374-3" available="true">\n  <title lang="en">Effective TypeScript</title>\n</book>'
+```
+
+**4. Namespaces and prefixes are literal text — write them however you need.**
+
+```typescript
+xml: {
+  template: `<xs:catalog xmlns:xs="http://example.com"><xs:book>{string}</xs:book></xs:catalog>`,
+  required: ["xs:book"],
+}
+```
+
+**5. For repeated elements, show one example — the model repeats the tag.**
+Use `arrays` to force single-item results into an array under `parse: true`.
+
+```typescript
+xml: {
+  template: `<library><book><title>{string}</title></book></library>`,
+  arrays: ["book"], // parse:true → library.book is always an array, even with 1 result
+}
+// model output: <library><book>...</book><book>...</book></library>
+```
+
+**6. `required` names must be present *and non-empty*, or the call retries — matched at any depth.**
+
+```typescript
+xml: { template: `<order><id>{string}</id><items>{string}</items></order>`, required: ["id", "items"] }
+// <order><id>ORD-1</id><items></items></order>  → retries (items is empty)
+```
+
+**7. `enforceLiterals: true` guarantees literal fidelity, deterministically.**
+Every non-`{}` value in the template is force-corrected in the output — even
+if the model changed it, or dropped the whole node. This closes the gap from
+rule 2, at the cost of re-serializing the output (formatting may differ
+slightly from the model's raw text, though it's always valid XML).
 
 ```typescript
 const result = await generate(model, {
   xml: {
-    template: `<book id="{string}" available="{boolean}">\n  <title lang="{string}">{string}</title>\n</book>`,
-    required: ["title"],
+    template: `<catalog updated="2026-01-01" totalBooks="90"><title>{string}</title></catalog>`,
+    enforceLiterals: true,
   },
-}, "Effective TypeScript, ISBN 978-1-4920-5374-3, in stock, English.");
+}, "The Road by Cormac McCarthy.");
 
-// result.data → '<book id="978-1-4920-5374-3" available="true">\n  <title lang="en">Effective TypeScript</title>\n</book>'
+// "updated" and "totalBooks" are guaranteed to stay exactly "2026-01-01" / "90",
+// regardless of anything in the prompt that might tempt the model to "correct" them
 ```
 
-The `xml` options:
+**8. The `<?xml ...?>` prolog is stripped by default — set `prolog: true` to keep it.**
+Models sometimes prepend a declaration on their own; most templates are meant
+to be fragments, not full documents, so it's stripped unless you ask for it.
+
+```typescript
+xml: { template: `<book>{string}</book>`, prolog: true }
+// result.data → '<?xml version="1.0" encoding="UTF-8"?>\n<book>...</book>'
+```
+
+**9. `parse: true` returns the parsed object instead of the XML string.**
+
+```typescript
+const result = await generate(model, {
+  xml: { template: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>`, parse: true },
+}, "Extract: John Doe, 35 years old.");
+
+console.log(result.data); // { name: "John Doe", age: 35 }
+```
+
+#### `xml` options reference
 
 | Option | Purpose |
 |---|---|
@@ -129,22 +218,11 @@ The `xml` options:
 | `required` | node names that must be present **and non-empty**, else retry (matched at any depth) |
 | `arrays` | node names to always coerce into arrays when `parse: true` |
 | `parse` | return the parsed object instead of the XML string |
-
-```typescript
-// parse: true → object
-const result = await generate(model, {
-  xml: {
-    template: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>`,
-    parse: true,
-  },
-}, "Extract: John Doe, 35 years old.");
-
-console.log(result.data); // { name: "John Doe", age: 35 }
-```
+| `prolog` | keep a `<?xml ...?>` declaration in the output (default: stripped) |
+| `enforceLiterals` | force every non-placeholder value to match the template exactly, deterministically |
 
 > XML is prompt-driven on all backends (no token-level constraint), so a capable
-> model gives the most reliable output on deeply nested templates. Use `required`
-> to guarantee the important nodes are actually filled in.
+> model gives the most reliable output on deeply nested templates.
 
 ## Backends & Guarantee Levels
 

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ console.log(result.attempts);       // 1
 
 ## Schema Inputs
 
-Shapecraft accepts four schema types — not just Zod.
+Shapecraft accepts five schema types — not just Zod.
 
 ### Zod Schema
 
@@ -86,6 +86,65 @@ const result = await generate(model, {
   hint: { type: "object", properties: { id: { type: "string" } } },
 }, prompt);
 ```
+
+### XML
+
+You provide an example XML template with `{string}` / `{number}` / `{boolean}`
+placeholders — the model fills it in. By default `result.data` is the **validated
+XML string** (the format you asked for); add `parse: true` to get a parsed JS
+object instead. Either way the output is validated as well-formed XML, and any
+`required` nodes must be present and non-empty or the call retries.
+
+```typescript
+const result = await generate(model, {
+  xml: {
+    template: `<book>\n  <title>{string}</title>\n  <author>{string}</author>\n  <year>{number}</year>\n</book>`,
+    required: ["title", "author"],
+  },
+}, 'Extract: "Clean Code" by Robert C. Martin, 2008.');
+
+console.log(result.data);
+// "<book>\n  <title>Clean Code</title>\n  <author>Robert C. Martin</author>\n  <year>2008</year>\n</book>"
+```
+
+Anything you write in the template is reproduced verbatim — including
+**attributes** and **namespaces**, which fall out for free:
+
+```typescript
+const result = await generate(model, {
+  xml: {
+    template: `<book id="{string}" available="{boolean}">\n  <title lang="{string}">{string}</title>\n</book>`,
+    required: ["title"],
+  },
+}, "Effective TypeScript, ISBN 978-1-4920-5374-3, in stock, English.");
+
+// result.data → '<book id="978-1-4920-5374-3" available="true">\n  <title lang="en">Effective TypeScript</title>\n</book>'
+```
+
+The `xml` options:
+
+| Option | Purpose |
+|---|---|
+| `template` | example XML with `{string}` / `{number}` / `{boolean}` placeholders |
+| `required` | node names that must be present **and non-empty**, else retry (matched at any depth) |
+| `arrays` | node names to always coerce into arrays when `parse: true` |
+| `parse` | return the parsed object instead of the XML string |
+
+```typescript
+// parse: true → object
+const result = await generate(model, {
+  xml: {
+    template: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>`,
+    parse: true,
+  },
+}, "Extract: John Doe, 35 years old.");
+
+console.log(result.data); // { name: "John Doe", age: 35 }
+```
+
+> XML is prompt-driven on all backends (no token-level constraint), so a capable
+> model gives the most reliable output on deeply nested templates. Use `required`
+> to guarantee the important nodes are actually filled in.
 
 ## Backends & Guarantee Levels
 

--- a/examples/xml-schema.ts
+++ b/examples/xml-schema.ts
@@ -1,0 +1,50 @@
+/**
+ * Example: XML output — model returns XML, parsed into a typed JS object
+ */
+import { generate, anthropic } from "@aviasole/shapecraft";
+
+const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+
+// ── Option A: xmlObject — declare a root tag and typed fields ────────────────
+// Supports nested objects, arrays of objects, and string/number/boolean leaves.
+const company = await generate(
+  model,
+  {
+    xmlObject: {
+      root: "company",
+      fields: {
+        name: "string",
+        founded: "number",
+        headquarters: { type: "object", fields: { city: "string", country: "string" } },
+        departments: {
+          type: "array",
+          items: {
+            name: "string",
+            headcount: "number",
+            lead: { type: "object", fields: { fullName: "string", yearsExperience: "number" } },
+          },
+        },
+      },
+    },
+  },
+  "Globex, founded 1989, HQ in Springfield, USA. Engineering has 42 people led " +
+    "by Jane Roe (12 yrs). Design has 8, led by Max Vane (7 yrs)."
+);
+console.log(company.data);
+// {
+//   name: "Globex",
+//   founded: 1989,
+//   headquarters: { city: "Springfield", country: "USA" },
+//   departments: [
+//     { name: "Engineering", headcount: 42, lead: { fullName: "Jane Roe", yearsExperience: 12 } },
+//     { name: "Design", headcount: 8, lead: { fullName: "Max Vane", yearsExperience: 7 } },
+//   ],
+// }
+
+// ── Option B: xmlTemplate — give an example shape with {placeholder} values ───
+const person = await generate(
+  model,
+  { xmlTemplate: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>` },
+  "Extract: John Doe, 35 years old."
+);
+console.log(person.data); // { name: "John Doe", age: 35 }

--- a/examples/xml-schema.ts
+++ b/examples/xml-schema.ts
@@ -1,50 +1,52 @@
 /**
- * Example: XML output — model returns XML, parsed into a typed JS object
+ * Example: XML output.
+ *
+ * You give an example XML template with {string}/{number}/{boolean} placeholders
+ * and the model fills it in. By default `result.data` is the validated XML string
+ * (the format you asked for); add `parse: true` to get a parsed object instead.
+ * Output is always validated as well-formed XML, and `required` nodes must be
+ * present and non-empty or the call retries.
  */
 import { generate, anthropic } from "@aviasole/shapecraft";
 
 const model = anthropic({ model: "claude-haiku-4-5-20251001" });
 
-// ── Option A: xmlObject — declare a root tag and typed fields ────────────────
-// Supports nested objects, arrays of objects, and string/number/boolean leaves.
-const company = await generate(
+// ── Default: XML string back ─────────────────────────────────────────────────
+const book = await generate(
   model,
   {
-    xmlObject: {
-      root: "company",
-      fields: {
-        name: "string",
-        founded: "number",
-        headquarters: { type: "object", fields: { city: "string", country: "string" } },
-        departments: {
-          type: "array",
-          items: {
-            name: "string",
-            headcount: "number",
-            lead: { type: "object", fields: { fullName: "string", yearsExperience: "number" } },
-          },
-        },
-      },
+    xml: {
+      template: `<book>\n  <title>{string}</title>\n  <author>{string}</author>\n  <year>{number}</year>\n</book>`,
+      required: ["title", "author"],
     },
   },
-  "Globex, founded 1989, HQ in Springfield, USA. Engineering has 42 people led " +
-    "by Jane Roe (12 yrs). Design has 8, led by Max Vane (7 yrs)."
+  'Extract: "Clean Code" by Robert C. Martin, 2008.'
 );
-console.log(company.data);
-// {
-//   name: "Globex",
-//   founded: 1989,
-//   headquarters: { city: "Springfield", country: "USA" },
-//   departments: [
-//     { name: "Engineering", headcount: 42, lead: { fullName: "Jane Roe", yearsExperience: 12 } },
-//     { name: "Design", headcount: 8, lead: { fullName: "Max Vane", yearsExperience: 7 } },
-//   ],
-// }
+console.log(book.data);
+// "<book>\n  <title>Clean Code</title>\n  <author>Robert C. Martin</author>\n  <year>2008</year>\n</book>"
 
-// ── Option B: xmlTemplate — give an example shape with {placeholder} values ───
+// ── Attributes & namespaces are reproduced verbatim ──────────────────────────
+const catalog = await generate(
+  model,
+  {
+    xml: {
+      template: `<xs:catalog xmlns:xs="http://example.com">\n  <xs:book id="{string}" available="{boolean}">\n    <xs:title lang="{string}">{string}</xs:title>\n    <xs:price currency="{string}">{number}</xs:price>\n  </xs:book>\n</xs:catalog>`,
+      required: ["xs:book", "xs:title", "xs:price"],
+    },
+  },
+  "Designing Data-Intensive Applications by Martin Kleppmann, ISBN 978-1-4493-7332-0, English, in stock, $54.99 USD."
+);
+console.log(catalog.data); // namespaced XML string with all attributes filled in
+
+// ── parse: true → typed object ───────────────────────────────────────────────
 const person = await generate(
   model,
-  { xmlTemplate: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>` },
+  {
+    xml: {
+      template: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>`,
+      parse: true,
+    },
+  },
   "Extract: John Doe, 35 years old."
 );
 console.log(person.data); // { name: "John Doe", age: 35 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,29 +1,40 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
         "zod-to-json-schema": "^3.23.0"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.107.0",
         "@types/node": "^20.0.0",
+        "groq-sdk": "^1.3.0",
+        "openai": "^6.45.0",
         "tsup": "^8.0.0",
         "typescript": "^5.4.0",
         "vitest": "^1.6.0"
       },
       "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.20.0",
+        "groq-sdk": ">=0.5.0",
         "node-llama-cpp": ">=3.0.0",
         "ollama": ">=0.5.0",
         "openai": ">=4.0.0",
         "zod": ">=3.0.0"
       },
       "peerDependenciesMeta": {
+        "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "groq-sdk": {
+          "optional": true
+        },
         "node-llama-cpp": {
           "optional": true
         },
@@ -32,7 +43,42 @@
         },
         "openai": {
           "optional": true
+        },
+        "zod": {
+          "optional": true
         }
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.107.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.107.0.tgz",
+      "integrity": "sha512-RWDWyvIeZnatUTzyX8+ayFzAqqLyoDHKnDEODFyW8H89zH+qEsh5h6XAmnbHY5DCoa58o3rjuNe3F3Hg851ayA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -886,6 +932,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -899,7 +952,6 @@
       "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1212,7 +1264,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1282,6 +1333,13 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "dev": true,
+      "license": "Unlicense"
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1350,6 +1408,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/groq-sdk": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-1.3.0.tgz",
+      "integrity": "sha512-mvgUIpAxlk/VxWIoliHx4R+Ha78Bd/g0t24OFjCXtdLbNiY1rW4h9AcznKBwFho7K/Nq732ZSjxMYkNb1xeCFg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "groq-sdk": "bin/cli"
+      }
+    },
     "node_modules/human-signals": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-5.0.0.tgz",
@@ -1396,6 +1464,20 @@
       "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -1590,6 +1672,37 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/openai": {
+      "version": "6.45.0",
+      "resolved": "https://registry.npmjs.org/openai/-/openai-6.45.0.tgz",
+      "integrity": "sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/credential-provider-node": ">=3.972.0 <4",
+        "@smithy/hash-node": ">=4.3.0 <5",
+        "@smithy/signature-v4": ">=5.4.0 <6",
+        "ws": "^8.18.0",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-provider-node": {
+          "optional": true
+        },
+        "@smithy/hash-node": {
+          "optional": true
+        },
+        "@smithy/signature-v4": {
+          "optional": true
+        },
+        "ws": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/p-limit": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
@@ -1646,7 +1759,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1696,7 +1808,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
@@ -1910,6 +2021,17 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
     "node_modules/std-env": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
@@ -2050,6 +2172,13 @@
         "tree-kill": "cli.js"
       }
     },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/ts-interface-checker": {
       "version": "0.1.13",
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
@@ -2126,7 +2255,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "fast-xml-parser": "^5.9.3",
         "zod-to-json-schema": "^3.23.0"
       },
       "devDependencies": {
@@ -575,6 +576,18 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@nodable/entities": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.2.0.tgz",
+      "integrity": "sha512-9uGyhaQavEUMC8AIddIjau4NsnsXhou+j5sBAGojCM1oxmQpVKTWR/9JxABD6UAv12vpIms55fPZKFQEhG6uBg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
@@ -1090,6 +1103,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/anynum": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+      "integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/assertion-error": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -1340,6 +1365,45 @@
       "dev": true,
       "license": "Unlicense"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.9.3.tgz",
+      "integrity": "sha512-brCNCeScma/kqa54J4PIDriSSSLssRkuYaUCpvHJulGc3HGI/xxKUCTDcYkAdqJsyb//ydpbxecjC3hB9+tb/g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.2.0",
+        "fast-xml-builder": "^1.2.0",
+        "is-unsafe": "^1.0.1",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.4.1",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fdir": {
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
@@ -1440,6 +1504,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/is-unsafe": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-1.0.1.tgz",
+      "integrity": "sha512-CLK2+VdgERgD96EYm5lUQssZYlRg2tkZnbsxZoacmSiRxiFJ4Nk4SzjCl+Ur+v3kXIY9dTIdb3IH22y1mZ56LA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1717,6 +1793,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/path-expression-matcher": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.1.tgz",
+      "integrity": "sha512-h7bxdzhHk8Knyc4Tj+jMaa7fEEoUJy7p1qtbVgkYg1Uhpe5Np5VuGXCRZnkZvU+Q42M1vStt0ifa3ueykRJPmQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/path-key": {
@@ -2063,6 +2154,21 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+      "integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "anynum": "^1.0.1"
       }
     },
     "node_modules/sucrase": {
@@ -2901,6 +3007,21 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -57,21 +57,34 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
-    "node-llama-cpp": ">=3.0.0",
-    "openai": ">=4.0.0",
-    "ollama": ">=0.5.0",
     "groq-sdk": ">=0.5.0",
+    "node-llama-cpp": ">=3.0.0",
+    "ollama": ">=0.5.0",
+    "openai": ">=4.0.0",
     "zod": ">=3.0.0"
   },
   "peerDependenciesMeta": {
-    "@anthropic-ai/sdk": { "optional": true },
-    "node-llama-cpp": { "optional": true },
-    "openai": { "optional": true },
-    "ollama": { "optional": true },
-    "groq-sdk": { "optional": true },
-    "zod": { "optional": true }
+    "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "node-llama-cpp": {
+      "optional": true
+    },
+    "openai": {
+      "optional": true
+    },
+    "ollama": {
+      "optional": true
+    },
+    "groq-sdk": {
+      "optional": true
+    },
+    "zod": {
+      "optional": true
+    }
   },
   "dependencies": {
+    "fast-xml-parser": "^5.9.3",
     "zod-to-json-schema": "^3.23.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -47,12 +47,16 @@
     "prepublishOnly": "npm run build && npm run typecheck && npm run test"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.107.0",
     "@types/node": "^20.0.0",
+    "groq-sdk": "^1.3.0",
+    "openai": "^6.45.0",
     "tsup": "^8.0.0",
     "typescript": "^5.4.0",
     "vitest": "^1.6.0"
   },
   "peerDependencies": {
+    "@anthropic-ai/sdk": ">=0.20.0",
     "node-llama-cpp": ">=3.0.0",
     "openai": ">=4.0.0",
     "ollama": ">=0.5.0",
@@ -60,10 +64,12 @@
     "zod": ">=3.0.0"
   },
   "peerDependenciesMeta": {
+    "@anthropic-ai/sdk": { "optional": true },
     "node-llama-cpp": { "optional": true },
     "openai": { "optional": true },
     "ollama": { "optional": true },
-    "groq-sdk": { "optional": true }
+    "groq-sdk": { "optional": true },
+    "zod": { "optional": true }
   },
   "dependencies": {
     "zod-to-json-schema": "^3.23.0"

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -1,6 +1,7 @@
 import type { SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
+import { isXmlInput } from "../core/validate.js";
 
 export interface GroqBackendOptions {
   model?: string;
@@ -33,7 +34,8 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
           { role: "system", content: system },
           { role: "user", content: user },
         ],
-        response_format: { type: "json_object" },
+        // XML schemas must not use json_object mode — Groq rejects it when prompt lacks "json"
+        ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
       });
 
       const raw: string = response.choices[0]?.message?.content ?? "";

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -7,10 +7,12 @@ import { parseAndValidate } from "../core/parse.js";
 export interface OllamaBackendOptions {
   model: string;
   host?: string;
+  timeoutMs?: number;
 }
 
 export function ollama(options: OllamaBackendOptions): ShapecraftModel {
   const host = options.host ?? "http://localhost:11434";
+  const timeoutMs = options.timeoutMs ?? 120_000;
 
   return {
     id: `ollama:${options.model}`,
@@ -28,6 +30,7 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
       }
 
       const response = await fetch(`${host}/api/chat`, {
+        signal: AbortSignal.timeout(timeoutMs),
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -1,6 +1,7 @@
 import type { SchemaInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
-import { isZodSchema } from "./validate.js";
+import { isZodSchema, isXmlInput } from "./validate.js";
+import { parseXml, validateXmlOutput } from "./xml.js";
 
 export function parseAndValidate<T>(
   raw: string,
@@ -9,6 +10,13 @@ export function parseAndValidate<T>(
 ): T {
   // Pattern schemas return the raw string directly — no JSON parsing
   if ("pattern" in (schema as object)) return raw as T;
+
+  // XML schemas — parse XML then validate structure
+  if (isXmlInput(schema)) {
+    const arrays = "xmlTemplate" in schema ? schema.arrays : undefined;
+    const parsed = parseXml(raw, arrays);
+    return validateXmlOutput<T>(parsed, schema);
+  }
 
   try {
     const text = opts.extractJson

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -1,7 +1,7 @@
 import type { SchemaInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
 import { isZodSchema, isXmlInput } from "./validate.js";
-import { parseXml, validateXmlOutput } from "./xml.js";
+import { parseXml, validateXmlOutput, cleanXml } from "./xml.js";
 
 export function parseAndValidate<T>(
   raw: string,
@@ -13,9 +13,10 @@ export function parseAndValidate<T>(
 
   // XML schemas — parse XML then validate structure
   if (isXmlInput(schema)) {
-    const arrays = "xmlTemplate" in schema ? schema.arrays : undefined;
-    const parsed = parseXml(raw, arrays);
-    return validateXmlOutput<T>(parsed, schema);
+    const parsed = parseXml(raw, schema.xml.arrays);
+    const validated = validateXmlOutput<T>(parsed, schema);
+    // Default: return the validated XML string. parse: true → return the parsed object.
+    return schema.xml.parse ? validated : (cleanXml(raw) as unknown as T);
   }
 
   try {

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -1,7 +1,7 @@
 import type { SchemaInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
 import { isZodSchema, isXmlInput } from "./validate.js";
-import { parseXml, validateXmlOutput, cleanXml } from "./xml.js";
+import { finalizeXmlOutput } from "./xml.js";
 
 export function parseAndValidate<T>(
   raw: string,
@@ -13,10 +13,7 @@ export function parseAndValidate<T>(
 
   // XML schemas — parse XML then validate structure
   if (isXmlInput(schema)) {
-    const parsed = parseXml(raw, schema.xml.arrays);
-    const validated = validateXmlOutput<T>(parsed, schema);
-    // Default: return the validated XML string. parse: true → return the parsed object.
-    return schema.xml.parse ? validated : (cleanXml(raw) as unknown as T);
+    return finalizeXmlOutput<T>(raw, schema);
   }
 
   try {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -1,6 +1,8 @@
 import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { SchemaInput, ValidatorInput } from "../types.js";
+import { buildXmlSystemPrompt } from "./xml.js";
+import { isXmlInput } from "./validate.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toJsonSchema(schema: z.ZodType<any>): Record<string, unknown> {
@@ -21,6 +23,8 @@ export function buildStructuredPrompt(
     schemaInfo = `Respond with valid JSON matching this schema exactly:\n\n${JSON.stringify(schema.jsonSchema, null, 2)}`;
   } else if ("pattern" in schema) {
     schemaInfo = `Respond with a plain string matching this pattern: ${schema.pattern}`;
+  } else if (isXmlInput(schema)) {
+    schemaInfo = buildXmlSystemPrompt(schema);
   } else if ("validate" in schema && (schema as ValidatorInput).hint) {
     schemaInfo = `Respond with valid JSON matching this schema exactly:\n\n${JSON.stringify((schema as ValidatorInput).hint, null, 2)}`;
   } else {

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,9 +1,22 @@
 import { z } from "zod";
-import type { SchemaInput } from "../types.js";
+import type { SchemaInput, XmlObjectInput, XmlTemplateInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
+import { parseXml, validateXmlOutput } from "./xml.js";
 
 export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
   return schema instanceof z.ZodType;
+}
+
+export function isXmlObjectInput(schema: SchemaInput): schema is XmlObjectInput {
+  return typeof schema === "object" && schema !== null && "xmlObject" in schema;
+}
+
+export function isXmlTemplateInput(schema: SchemaInput): schema is XmlTemplateInput {
+  return typeof schema === "object" && schema !== null && "xmlTemplate" in schema;
+}
+
+export function isXmlInput(schema: SchemaInput): schema is XmlObjectInput | XmlTemplateInput {
+  return isXmlObjectInput(schema) || isXmlTemplateInput(schema);
 }
 
 function nullToUndefined(value: unknown): unknown {
@@ -82,6 +95,17 @@ export function validateOutput<T>(output: unknown, schema: SchemaInput<T>): T {
     if (!schema.validate(output)) {
       throw new SchemaViolationError(JSON.stringify(output), "Custom validator returned false");
     }
+    return output as T;
+  }
+
+  if (isXmlInput(schema)) {
+    if (typeof output === "string") {
+      // raw XML string (e.g. from mock models) — parse and validate now
+      const arrays = "xmlTemplate" in schema ? schema.arrays : undefined;
+      const parsed = parseXml(output, arrays);
+      return validateXmlOutput<T>(parsed, schema);
+    }
+    // already parsed by a real backend — pass through
     return output as T;
   }
 

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { SchemaInput, XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
-import { parseXml, validateXmlOutput, cleanXml } from "./xml.js";
+import { finalizeXmlOutput } from "./xml.js";
 
 export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
   return schema instanceof z.ZodType;
@@ -93,9 +93,7 @@ export function validateOutput<T>(output: unknown, schema: SchemaInput<T>): T {
   if (isXmlInput(schema)) {
     if (typeof output === "string") {
       // raw XML string (from mock models, or the default string path) — validate now
-      const parsed = parseXml(output, schema.xml.arrays);
-      const validated = validateXmlOutput<T>(parsed, schema);
-      return schema.xml.parse ? validated : (cleanXml(output) as unknown as T);
+      return finalizeXmlOutput<T>(output, schema);
     }
     // already parsed by a real backend — pass through
     return output as T;

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,22 +1,14 @@
 import { z } from "zod";
-import type { SchemaInput, XmlObjectInput, XmlTemplateInput } from "../types.js";
+import type { SchemaInput, XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
-import { parseXml, validateXmlOutput } from "./xml.js";
+import { parseXml, validateXmlOutput, cleanXml } from "./xml.js";
 
 export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
   return schema instanceof z.ZodType;
 }
 
-export function isXmlObjectInput(schema: SchemaInput): schema is XmlObjectInput {
-  return typeof schema === "object" && schema !== null && "xmlObject" in schema;
-}
-
-export function isXmlTemplateInput(schema: SchemaInput): schema is XmlTemplateInput {
-  return typeof schema === "object" && schema !== null && "xmlTemplate" in schema;
-}
-
-export function isXmlInput(schema: SchemaInput): schema is XmlObjectInput | XmlTemplateInput {
-  return isXmlObjectInput(schema) || isXmlTemplateInput(schema);
+export function isXmlInput(schema: SchemaInput): schema is XmlInput {
+  return typeof schema === "object" && schema !== null && "xml" in schema;
 }
 
 function nullToUndefined(value: unknown): unknown {
@@ -100,10 +92,10 @@ export function validateOutput<T>(output: unknown, schema: SchemaInput<T>): T {
 
   if (isXmlInput(schema)) {
     if (typeof output === "string") {
-      // raw XML string (e.g. from mock models) — parse and validate now
-      const arrays = "xmlTemplate" in schema ? schema.arrays : undefined;
-      const parsed = parseXml(output, arrays);
-      return validateXmlOutput<T>(parsed, schema);
+      // raw XML string (from mock models, or the default string path) — validate now
+      const parsed = parseXml(output, schema.xml.arrays);
+      const validated = validateXmlOutput<T>(parsed, schema);
+      return schema.xml.parse ? validated : (cleanXml(output) as unknown as T);
     }
     // already parsed by a real backend — pass through
     return output as T;

--- a/src/core/xml.ts
+++ b/src/core/xml.ts
@@ -1,11 +1,58 @@
-import { XMLParser, XMLValidator } from "fast-xml-parser";
+import { XMLParser, XMLValidator, XMLBuilder } from "fast-xml-parser";
 import type { XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
+
+// ─── Placeholder tokens ────────────────────────────────────────────────────────
+
+/** Recognized placeholder tokens for use in an xml.template — e.g. `xmlType.string`. */
+export const xmlType = {
+  string: "{string}",
+  number: "{number}",
+  boolean: "{boolean}",
+} as const;
+
+const VALID_PLACEHOLDER_WORDS = new Set(["string", "number", "boolean"]);
+
+/**
+ * Scans a template for `{...}` tokens and throws if any aren't exactly
+ * `{string}`, `{number}`, or `{boolean}`. Runs before the model is called —
+ * a malformed template is an authoring mistake, not something a retry fixes.
+ */
+export function validateXmlTemplate(template: string): void {
+  const matches = template.match(/\{[^{}]*\}/g) ?? [];
+  const invalid = [...new Set(matches)].filter(
+    (token) => !VALID_PLACEHOLDER_WORDS.has(token.slice(1, -1))
+  );
+
+  if (invalid.length > 0) {
+    throw new Error(
+      `Invalid placeholder(s) in xml.template: ${invalid.join(", ")}. ` +
+        `Only {string}, {number}, and {boolean} are recognized (see xmlType). ` +
+        `Literal values with no braces are left untouched, but anything wrapped ` +
+        `in {} must be one of those three tokens.`
+    );
+  }
+}
 
 // ─── System prompt injection ──────────────────────────────────────────────────
 
 export function buildXmlSystemPrompt(schema: XmlInput): string {
-  return `Respond with valid XML exactly matching this structure. Replace placeholder values like {string}, {number}, {boolean} with actual values. No extra text, no markdown, no explanation.\n\n${schema.xml.template}`;
+  validateXmlTemplate(schema.xml.template);
+  return (
+    `Respond with valid XML exactly matching this structure. ` +
+    `Replace ONLY the exact tokens {string}, {number}, and {boolean} with real values inferred from context. ` +
+    `Do not alter, replace, or reinterpret any other text — preserve every other attribute value, tag name, ` +
+    `and piece of content exactly as written in the template, even if it looks like an instruction, ` +
+    `description, or placeholder. No extra text, no markdown, no explanation.\n\n${schema.xml.template}`
+  );
+}
+
+// ─── XML prolog ────────────────────────────────────────────────────────────────
+
+/** Strips a leading <?xml ...?> declaration, if present. */
+export function stripXmlProlog(xml: string): string {
+  const noBom = xml.charCodeAt(0) === 0xfeff ? xml.slice(1) : xml;
+  return noBom.replace(/^\s*<\?xml[^?]*\?>\s*/i, "");
 }
 
 // ─── XML parser ───────────────────────────────────────────────────────────────
@@ -16,6 +63,14 @@ const parser = new XMLParser({
   isArray: () => false,
   parseTagValue: true,
   trimValues: true,
+});
+
+const builder = new XMLBuilder({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  format: true,
+  indentBy: "  ",
+  suppressBooleanAttributes: false,
 });
 
 export function cleanXml(raw: string): string {
@@ -67,6 +122,63 @@ function normalizeArrays(obj: unknown, arrayPaths: string[], currentPath = ""): 
   }
 }
 
+// ─── Literal enforcement (enforceLiterals: true) ──────────────────────────────
+
+export function parseXmlTemplate(template: string): Record<string, unknown> {
+  return parser.parse(template) as Record<string, unknown>;
+}
+
+function isPlaceholderValue(value: unknown): boolean {
+  return typeof value === "string" && (value === xmlType.string || value === xmlType.number || value === xmlType.boolean);
+}
+
+/**
+ * Force every literal (non-placeholder) leaf in `templateNode` to appear
+ * unchanged in the reconciled result — regardless of what `outputNode` has
+ * there. Placeholder leaves ({string}/{number}/{boolean}) keep the model's
+ * value as-is. Extra keys the model added beyond the template are preserved.
+ */
+export function reconcileLiterals(templateNode: unknown, outputNode: unknown): unknown {
+  // Leaf value in the template (string/number/boolean, not an object)
+  if (templateNode === null || typeof templateNode !== "object") {
+    return isPlaceholderValue(templateNode) ? outputNode : templateNode;
+  }
+
+  // Template says "this repeats" only implicitly — reconciliation follows
+  // whatever shape the (already-validated) output actually has for arrays.
+  if (Array.isArray(outputNode)) {
+    return outputNode.map((item) => reconcileLiterals(templateNode, item));
+  }
+
+  const templateObj = templateNode as Record<string, unknown>;
+  const outputWasMissing = outputNode === undefined;
+  const outputObj =
+    outputNode !== null && typeof outputNode === "object" && !Array.isArray(outputNode)
+      ? (outputNode as Record<string, unknown>)
+      : {};
+
+  const result: Record<string, unknown> = { ...outputObj };
+
+  for (const key of Object.keys(templateObj)) {
+    const reconciled = reconcileLiterals(templateObj[key], outputObj[key]);
+    if (reconciled !== undefined) {
+      result[key] = reconciled;
+    } else {
+      delete result[key];
+    }
+  }
+
+  // A whole subtree the model omitted, with nothing literal to force in —
+  // stay omitted rather than injecting a spurious empty tag.
+  if (outputWasMissing && Object.keys(result).length === 0) return undefined;
+
+  return result;
+}
+
+export function buildXmlFromTree(tree: Record<string, unknown>): string {
+  return builder.build(tree).trim();
+}
+
 // ─── Required-node validation ─────────────────────────────────────────────────
 
 function isNonEmpty(value: unknown): boolean {
@@ -107,4 +219,27 @@ export function validateXmlOutput<T>(parsed: Record<string, unknown>, schema: Xm
   const keys = Object.keys(parsed);
   if (keys.length === 1) return parsed[keys[0]] as T;
   return parsed as T;
+}
+
+// ─── Full pipeline: parse → (optionally reconcile) → validate → format ────────
+
+export function finalizeXmlOutput<T>(raw: string, schema: XmlInput): T {
+  let parsed = parseXml(raw, schema.xml.arrays);
+
+  if (schema.xml.enforceLiterals) {
+    const templateTree = parseXmlTemplate(schema.xml.template);
+    parsed = reconcileLiterals(templateTree, parsed) as Record<string, unknown>;
+  }
+
+  const validated = validateXmlOutput<T>(parsed, schema);
+  if (schema.xml.parse) return validated;
+
+  if (schema.xml.enforceLiterals) {
+    const rebuilt = buildXmlFromTree(parsed);
+    return (schema.xml.prolog ? `<?xml version="1.0" encoding="UTF-8"?>\n${rebuilt}` : rebuilt) as unknown as T;
+  }
+
+  // Default: pass through the model's own text, prolog stripped unless prolog: true.
+  const cleaned = cleanXml(raw);
+  return (schema.xml.prolog ? cleaned : stripXmlProlog(cleaned)) as unknown as T;
 }

--- a/src/core/xml.ts
+++ b/src/core/xml.ts
@@ -1,0 +1,154 @@
+import { XMLParser } from "fast-xml-parser";
+import type { XmlObjectInput, XmlTemplateInput, XmlFields, XmlFieldDef } from "../types.js";
+import { SchemaViolationError } from "../types.js";
+
+// ─── Template builder (Option A → template string) ───────────────────────────
+
+function fieldDefToXml(name: string, def: XmlFieldDef, indent: string): string {
+  if (typeof def === "string") {
+    return `${indent}<${name}>{${def}}</${name}>`;
+  }
+  if (def.type === "object") {
+    const inner = fieldsToXml(def.fields, indent + "  ");
+    return `${indent}<${name}>\n${inner}\n${indent}</${name}>`;
+  }
+  if (def.type === "array") {
+    const inner = fieldsToXml(def.items, indent + "    ");
+    return `${indent}<${name}>\n${indent}  <item>\n${inner}\n${indent}  </item>\n${indent}</${name}>`;
+  }
+  return `${indent}<${name}>{${def.type}}</${name}>`;
+}
+
+function fieldsToXml(fields: XmlFields, indent: string): string {
+  return Object.entries(fields)
+    .map(([name, def]) => fieldDefToXml(name, def, indent))
+    .join("\n");
+}
+
+export function xmlObjectToTemplate(input: XmlObjectInput): string {
+  const { root, fields } = input.xmlObject;
+  const inner = fieldsToXml(fields, "  ");
+  return `<${root}>\n${inner}\n</${root}>`;
+}
+
+// ─── System prompt injection ──────────────────────────────────────────────────
+
+export function buildXmlSystemPrompt(schema: XmlObjectInput | XmlTemplateInput): string {
+  const template =
+    "xmlObject" in schema ? xmlObjectToTemplate(schema) : schema.xmlTemplate;
+  return `Respond with valid XML exactly matching this structure. Replace placeholder values like {string}, {number}, {boolean} with actual values. No extra text, no markdown, no explanation.\n\n${template}`;
+}
+
+// ─── XML parser ───────────────────────────────────────────────────────────────
+
+const parser = new XMLParser({
+  ignoreAttributes: false,
+  attributeNamePrefix: "@_",
+  isArray: () => false,
+  parseTagValue: true,
+  trimValues: true,
+});
+
+export function parseXml(raw: string, arrays?: string[]): Record<string, unknown> {
+  const cleaned = raw.trim().replace(/^```xml\s*/i, "").replace(/```\s*$/, "").trim();
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = parser.parse(cleaned) as Record<string, unknown>;
+  } catch (err) {
+    throw new SchemaViolationError(raw, `Invalid XML: ${err}`);
+  }
+
+  if (arrays && arrays.length > 0) {
+    normalizeArrays(parsed, arrays);
+  }
+
+  return parsed;
+}
+
+function normalizeArrays(obj: unknown, arrayPaths: string[], currentPath = ""): void {
+  if (typeof obj !== "object" || obj === null) return;
+
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    const path = currentPath ? `${currentPath}.${key}` : key;
+    const matchedPath = arrayPaths.find((p) => p === key || p === path);
+
+    if (matchedPath && value !== undefined && !Array.isArray(value)) {
+      (obj as Record<string, unknown>)[key] = [value];
+    }
+
+    if (typeof value === "object" && value !== null) {
+      normalizeArrays(value, arrayPaths, path);
+    }
+  }
+}
+
+// ─── Validation ───────────────────────────────────────────────────────────────
+
+function coerceField(value: unknown, type: string): unknown {
+  if (type === "number") return typeof value === "number" ? value : Number(value);
+  if (type === "boolean") {
+    if (typeof value === "boolean") return value;
+    if (value === "true") return true;
+    if (value === "false") return false;
+    return Boolean(value);
+  }
+  return String(value ?? "");
+}
+
+function validateFields(obj: Record<string, unknown>, fields: XmlFields, path: string): void {
+  for (const [key, def] of Object.entries(fields)) {
+    const fieldPath = path ? `${path}.${key}` : key;
+    if (!(key in obj)) {
+      throw new Error(`Missing required field: <${fieldPath}>`);
+    }
+
+    const value = obj[key];
+    const type = typeof def === "string" ? def : def.type;
+
+    if (type === "object" && typeof def === "object" && def.type === "object") {
+      if (typeof value !== "object" || value === null || Array.isArray(value)) {
+        throw new Error(`Expected object at <${fieldPath}>`);
+      }
+      validateFields(value as Record<string, unknown>, def.fields, fieldPath);
+    } else if (type === "array" && typeof def === "object" && def.type === "array") {
+      const items = Array.isArray(value) ? value : [value];
+      for (const item of items) {
+        if (typeof item !== "object" || item === null) {
+          throw new Error(`Expected object items in <${fieldPath}>`);
+        }
+        validateFields(item as Record<string, unknown>, def.items, fieldPath);
+      }
+      obj[key] = items;
+    } else if (type === "string" || type === "number" || type === "boolean") {
+      obj[key] = coerceField(value, type);
+    }
+  }
+}
+
+export function validateXmlOutput<T>(
+  parsed: Record<string, unknown>,
+  schema: XmlObjectInput | XmlTemplateInput
+): T {
+  if ("xmlObject" in schema) {
+    const { root, fields } = schema.xmlObject;
+    const rootValue = parsed[root];
+    if (rootValue === undefined) {
+      throw new SchemaViolationError(JSON.stringify(parsed), `Missing root element <${root}>`);
+    }
+    if (typeof rootValue !== "object" || rootValue === null) {
+      throw new SchemaViolationError(JSON.stringify(parsed), `Root element <${root}> must be an object`);
+    }
+    try {
+      validateFields(rootValue as Record<string, unknown>, fields, root);
+    } catch (err) {
+      throw new SchemaViolationError(JSON.stringify(parsed), err);
+    }
+    return rootValue as T;
+  }
+
+  // xmlTemplate — no strict field validation, return root element or full parsed object
+  const keys = Object.keys(parsed);
+  if (keys.length === 1) return parsed[keys[0]] as T;
+  return parsed as T;
+}

--- a/src/core/xml.ts
+++ b/src/core/xml.ts
@@ -112,7 +112,13 @@ function validateFields(obj: Record<string, unknown>, fields: XmlFields, path: s
       }
       validateFields(value as Record<string, unknown>, def.fields, fieldPath);
     } else if (type === "array" && typeof def === "object" && def.type === "array") {
-      const items = Array.isArray(value) ? value : [value];
+      // Array items are emitted as repeated <item> tags, so the parser yields
+      // { item: [...] } (or { item: {...} } for a single entry). Unwrap that.
+      let raw: unknown = value;
+      if (raw && typeof raw === "object" && !Array.isArray(raw) && "item" in (raw as object)) {
+        raw = (raw as Record<string, unknown>).item;
+      }
+      const items = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
       for (const item of items) {
         if (typeof item !== "object" || item === null) {
           throw new Error(`Expected object items in <${fieldPath}>`);

--- a/src/core/xml.ts
+++ b/src/core/xml.ts
@@ -1,42 +1,11 @@
-import { XMLParser } from "fast-xml-parser";
-import type { XmlObjectInput, XmlTemplateInput, XmlFields, XmlFieldDef } from "../types.js";
+import { XMLParser, XMLValidator } from "fast-xml-parser";
+import type { XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
-
-// ─── Template builder (Option A → template string) ───────────────────────────
-
-function fieldDefToXml(name: string, def: XmlFieldDef, indent: string): string {
-  if (typeof def === "string") {
-    return `${indent}<${name}>{${def}}</${name}>`;
-  }
-  if (def.type === "object") {
-    const inner = fieldsToXml(def.fields, indent + "  ");
-    return `${indent}<${name}>\n${inner}\n${indent}</${name}>`;
-  }
-  if (def.type === "array") {
-    const inner = fieldsToXml(def.items, indent + "    ");
-    return `${indent}<${name}>\n${indent}  <item>\n${inner}\n${indent}  </item>\n${indent}</${name}>`;
-  }
-  return `${indent}<${name}>{${def.type}}</${name}>`;
-}
-
-function fieldsToXml(fields: XmlFields, indent: string): string {
-  return Object.entries(fields)
-    .map(([name, def]) => fieldDefToXml(name, def, indent))
-    .join("\n");
-}
-
-export function xmlObjectToTemplate(input: XmlObjectInput): string {
-  const { root, fields } = input.xmlObject;
-  const inner = fieldsToXml(fields, "  ");
-  return `<${root}>\n${inner}\n</${root}>`;
-}
 
 // ─── System prompt injection ──────────────────────────────────────────────────
 
-export function buildXmlSystemPrompt(schema: XmlObjectInput | XmlTemplateInput): string {
-  const template =
-    "xmlObject" in schema ? xmlObjectToTemplate(schema) : schema.xmlTemplate;
-  return `Respond with valid XML exactly matching this structure. Replace placeholder values like {string}, {number}, {boolean} with actual values. No extra text, no markdown, no explanation.\n\n${template}`;
+export function buildXmlSystemPrompt(schema: XmlInput): string {
+  return `Respond with valid XML exactly matching this structure. Replace placeholder values like {string}, {number}, {boolean} with actual values. No extra text, no markdown, no explanation.\n\n${schema.xml.template}`;
 }
 
 // ─── XML parser ───────────────────────────────────────────────────────────────
@@ -49,8 +18,23 @@ const parser = new XMLParser({
   trimValues: true,
 });
 
+export function cleanXml(raw: string): string {
+  return raw.trim().replace(/^```xml\s*/i, "").replace(/```\s*$/, "").trim();
+}
+
 export function parseXml(raw: string, arrays?: string[]): Record<string, unknown> {
-  const cleaned = raw.trim().replace(/^```xml\s*/i, "").replace(/```\s*$/, "").trim();
+  const cleaned = cleanXml(raw);
+
+  // Opt-in debug: set SHAPECRAFT_DEBUG_XML=1 to log the raw model output.
+  if (process.env.SHAPECRAFT_DEBUG_XML) {
+    console.error("[shapecraft:xml] raw model output:\n" + raw);
+  }
+
+  // fast-xml-parser's parser is lenient, so validate well-formedness explicitly.
+  const valid = XMLValidator.validate(cleaned);
+  if (valid !== true) {
+    throw new SchemaViolationError(raw, `Invalid XML: ${valid.err?.msg ?? "malformed"}`);
+  }
 
   let parsed: Record<string, unknown>;
   try {
@@ -83,77 +67,43 @@ function normalizeArrays(obj: unknown, arrayPaths: string[], currentPath = ""): 
   }
 }
 
-// ─── Validation ───────────────────────────────────────────────────────────────
+// ─── Required-node validation ─────────────────────────────────────────────────
 
-function coerceField(value: unknown, type: string): unknown {
-  if (type === "number") return typeof value === "number" ? value : Number(value);
-  if (type === "boolean") {
-    if (typeof value === "boolean") return value;
-    if (value === "true") return true;
-    if (value === "false") return false;
-    return Boolean(value);
-  }
-  return String(value ?? "");
+function isNonEmpty(value: unknown): boolean {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim().length > 0;
+  if (Array.isArray(value)) return value.length > 0 && value.some(isNonEmpty);
+  if (typeof value === "object") return Object.keys(value).length > 0;
+  return true; // numbers, booleans
 }
 
-function validateFields(obj: Record<string, unknown>, fields: XmlFields, path: string): void {
-  for (const [key, def] of Object.entries(fields)) {
-    const fieldPath = path ? `${path}.${key}` : key;
-    if (!(key in obj)) {
-      throw new Error(`Missing required field: <${fieldPath}>`);
-    }
-
-    const value = obj[key];
-    const type = typeof def === "string" ? def : def.type;
-
-    if (type === "object" && typeof def === "object" && def.type === "object") {
-      if (typeof value !== "object" || value === null || Array.isArray(value)) {
-        throw new Error(`Expected object at <${fieldPath}>`);
-      }
-      validateFields(value as Record<string, unknown>, def.fields, fieldPath);
-    } else if (type === "array" && typeof def === "object" && def.type === "array") {
-      // Array items are emitted as repeated <item> tags, so the parser yields
-      // { item: [...] } (or { item: {...} } for a single entry). Unwrap that.
-      let raw: unknown = value;
-      if (raw && typeof raw === "object" && !Array.isArray(raw) && "item" in (raw as object)) {
-        raw = (raw as Record<string, unknown>).item;
-      }
-      const items = Array.isArray(raw) ? raw : raw == null ? [] : [raw];
-      for (const item of items) {
-        if (typeof item !== "object" || item === null) {
-          throw new Error(`Expected object items in <${fieldPath}>`);
-        }
-        validateFields(item as Record<string, unknown>, def.items, fieldPath);
-      }
-      obj[key] = items;
-    } else if (type === "string" || type === "number" || type === "boolean") {
-      obj[key] = coerceField(value, type);
-    }
+/** True if `name` exists anywhere in the tree with a non-empty value. */
+function deepHasNonEmpty(obj: unknown, name: string): boolean {
+  if (typeof obj !== "object" || obj === null) return false;
+  for (const [key, value] of Object.entries(obj as Record<string, unknown>)) {
+    if (key === name && isNonEmpty(value)) return true;
+    if (deepHasNonEmpty(value, name)) return true;
   }
+  return false;
 }
 
-export function validateXmlOutput<T>(
-  parsed: Record<string, unknown>,
-  schema: XmlObjectInput | XmlTemplateInput
-): T {
-  if ("xmlObject" in schema) {
-    const { root, fields } = schema.xmlObject;
-    const rootValue = parsed[root];
-    if (rootValue === undefined) {
-      throw new SchemaViolationError(JSON.stringify(parsed), `Missing root element <${root}>`);
+// ─── Output validation ────────────────────────────────────────────────────────
+
+export function validateXmlOutput<T>(parsed: Record<string, unknown>, schema: XmlInput): T {
+  const { required } = schema.xml;
+
+  if (required && required.length > 0) {
+    for (const name of required) {
+      if (!deepHasNonEmpty(parsed, name)) {
+        throw new SchemaViolationError(
+          JSON.stringify(parsed),
+          `Missing or empty required node: <${name}>`
+        );
+      }
     }
-    if (typeof rootValue !== "object" || rootValue === null) {
-      throw new SchemaViolationError(JSON.stringify(parsed), `Root element <${root}> must be an object`);
-    }
-    try {
-      validateFields(rootValue as Record<string, unknown>, fields, root);
-    } catch (err) {
-      throw new SchemaViolationError(JSON.stringify(parsed), err);
-    }
-    return rootValue as T;
   }
 
-  // xmlTemplate — no strict field validation, return root element or full parsed object
+  // Unwrap the single root element for the parse: true path.
   const keys = Object.keys(parsed);
   if (keys.length === 1) return parsed[keys[0]] as T;
   return parsed as T;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,11 @@ export type {
   GenerateOptions,
   GenerateResult,
   GuaranteeLevel,
+  XmlObjectInput,
+  XmlTemplateInput,
+  XmlFields,
+  XmlFieldDef,
+  XmlFieldType,
 } from "./types.js";
 
 export { SchemaViolationError, MaxRetriesExceededError } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,11 +9,7 @@ export type {
   GenerateOptions,
   GenerateResult,
   GuaranteeLevel,
-  XmlObjectInput,
-  XmlTemplateInput,
-  XmlFields,
-  XmlFieldDef,
-  XmlFieldType,
+  XmlInput,
 } from "./types.js";
 
 export { SchemaViolationError, MaxRetriesExceededError } from "./types.js";

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { generate } from "./core/generate.js";
 export { toJsonSchema, buildStructuredPrompt } from "./core/schema.js";
+export { xmlType, validateXmlTemplate } from "./core/xml.js";
 
 export * from "./backends/index.js";
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,28 +6,21 @@ export type JsonSchemaInput = { jsonSchema: Record<string, unknown> };
 export type PatternInput = { pattern: RegExp };
 export type ValidatorInput = { validate: (output: unknown) => boolean; hint?: Record<string, unknown> };
 
-export type XmlFieldType = "string" | "number" | "boolean";
-export type XmlFieldDef =
-  | XmlFieldType
-  | { type: XmlFieldType }
-  | { type: "object"; fields: XmlFields }
-  | { type: "array"; items: XmlFields };
-export type XmlFields = Record<string, XmlFieldDef>;
-
-export type XmlObjectInput = {
-  xmlObject: {
-    root: string;
-    fields: XmlFields;
+export type XmlInput = {
+  xml: {
+    /** Example XML with {string} / {number} / {boolean} placeholders. */
+    template: string;
+    /** Node names that must be present and non-empty in the output, else retry. */
+    required?: string[];
+    /** Node names to always coerce into arrays when parsing. */
+    arrays?: string[];
+    /** Return the parsed object instead of the validated XML string (the default). */
+    parse?: boolean;
   };
 };
 
-export type XmlTemplateInput = {
-  xmlTemplate: string;
-  arrays?: string[];
-};
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput | XmlObjectInput | XmlTemplateInput;
+export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput | XmlInput;
 
 export interface ShapecraftModel {
   id: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,15 @@ export type XmlInput = {
     arrays?: string[];
     /** Return the parsed object instead of the validated XML string (the default). */
     parse?: boolean;
+    /** Keep an <?xml ...?> prolog if the model adds one (default: stripped). */
+    prolog?: boolean;
+    /**
+     * Force every non-placeholder (literal) value in the template to appear
+     * unchanged in the output, regardless of what the model returns for it.
+     * Re-serializes the output from a reconciled tree, so formatting
+     * (whitespace, attribute order) may differ from the model's raw text.
+     */
+    enforceLiterals?: boolean;
   };
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,29 @@ export type GuaranteeLevel = "constrained" | "native" | "best-effort";
 export type JsonSchemaInput = { jsonSchema: Record<string, unknown> };
 export type PatternInput = { pattern: RegExp };
 export type ValidatorInput = { validate: (output: unknown) => boolean; hint?: Record<string, unknown> };
+
+export type XmlFieldType = "string" | "number" | "boolean";
+export type XmlFieldDef =
+  | XmlFieldType
+  | { type: XmlFieldType }
+  | { type: "object"; fields: XmlFields }
+  | { type: "array"; items: XmlFields };
+export type XmlFields = Record<string, XmlFieldDef>;
+
+export type XmlObjectInput = {
+  xmlObject: {
+    root: string;
+    fields: XmlFields;
+  };
+};
+
+export type XmlTemplateInput = {
+  xmlTemplate: string;
+  arrays?: string[];
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput;
+export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput | XmlObjectInput | XmlTemplateInput;
 
 export interface ShapecraftModel {
   id: string;

--- a/tests/schema-priority.test.ts
+++ b/tests/schema-priority.test.ts
@@ -255,7 +255,9 @@ describe("Schema priority — Groq backend (real API)", () => {
 });
 
 describe("Schema priority — Ollama backend (real API)", () => {
-  const hasOllama = true;
+  // Opt-in: needs a running Ollama server. Set OLLAMA_MODEL to enable locally;
+  // skipped in CI where no Ollama is reachable on :11434.
+  const hasOllama = !!process.env.OLLAMA_MODEL;
   const ollamaModel = process.env.OLLAMA_MODEL ?? "nemotron-3-super:cloud";
 
   it.skipIf(!hasOllama)("schema arg enforced: returns SchemaA-shaped data", async () => {

--- a/tests/schema-priority.test.ts
+++ b/tests/schema-priority.test.ts
@@ -168,7 +168,7 @@ describe("Schema priority — validation always enforces schema argument", () =>
 // ─── Per-backend — real API calls, skipped when key not in .env ──────────────
 
 const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
-const hasOpenAI    = false; // OpenAI quota exceeded — re-enable when credits added
+const hasOpenAI    = !!process.env.OPENAI_API_KEY;
 const hasGroq      = !!process.env.GROQ_API_KEY;
 
 describe("Schema priority — Anthropic backend (real API)", () => {

--- a/tests/schema-priority.test.ts
+++ b/tests/schema-priority.test.ts
@@ -1,0 +1,316 @@
+/**
+ * Schema priority tests — what happens when two conflicting schemas are provided:
+ *   1. schema argument  → drives both buildStructuredPrompt injection AND validateOutput
+ *   2. systemPrompt     → user-supplied context, also injected into system prompt
+ *
+ * The schema argument ALWAYS wins for validation — systemPrompt schema is just text the LLM sees.
+ * These tests prove that and show where the conflict surfaces per backend.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { generate } from "../src/core/generate.js";
+import { buildStructuredPrompt } from "../src/core/schema.js";
+import { anthropic } from "../src/backends/anthropic.js";
+import { openai } from "../src/backends/openai.js";
+import { groq } from "../src/backends/groq.js";
+import { ollama } from "../src/backends/ollama.js";
+import { MaxRetriesExceededError } from "../src/types.js";
+import type { ShapecraftModel } from "../src/types.js";
+
+// ─── Schemas ─────────────────────────────────────────────────────────────────
+
+// Schema A — passed as the schema argument
+const SchemaA = {
+  type: "object",
+  required: ["id", "score"],
+  properties: {
+    id:    { type: "string" },
+    score: { type: "number" },
+  },
+} as const;
+
+// Schema B — mentioned only in systemPrompt (the "conflicting" one)
+const SchemaBDescription = `
+Return JSON with this shape:
+{
+  "username": "<string>",
+  "level": <number>
+}
+`;
+
+// ─── buildStructuredPrompt inspection ────────────────────────────────────────
+
+describe("Schema priority — system prompt composition", () => {
+  it("schema arg schema appears in system prompt even when systemPrompt is provided", () => {
+    const { system } = buildStructuredPrompt("do something", { jsonSchema: SchemaA }, "You are helpful.");
+    // Schema A fields injected by shapecraft
+    expect(system).toContain('"id"');
+    expect(system).toContain('"score"');
+    // User system prompt preserved
+    expect(system).toContain("You are helpful.");
+  });
+
+  it("system prompt with conflicting schema B — both appear in the final system string", () => {
+    const { system } = buildStructuredPrompt(
+      "do something",
+      { jsonSchema: SchemaA },
+      `You are helpful. ${SchemaBDescription}`
+    );
+    // Both schemas visible in system prompt — LLM sees a conflict
+    expect(system).toContain('"id"');    // from SchemaA (schema arg)
+    expect(system).toContain('"score"'); // from SchemaA (schema arg)
+    expect(system).toContain("username"); // from SchemaB (systemPrompt)
+    expect(system).toContain("level");   // from SchemaB (systemPrompt)
+  });
+
+  it("schema arg instruction always appended AFTER user system prompt", () => {
+    const { system } = buildStructuredPrompt(
+      "do something",
+      { jsonSchema: SchemaA },
+      "You are helpful."
+    );
+    const userPromptPos  = system.indexOf("You are helpful.");
+    const schemaInjectPos = system.indexOf("Respond with valid JSON");
+    // Schema injection comes after user system prompt
+    expect(schemaInjectPos).toBeGreaterThan(userPromptPos);
+  });
+});
+
+// ─── Validation priority — schema arg always enforced ────────────────────────
+
+describe("Schema priority — validation always enforces schema argument", () => {
+  it("model returns SchemaA-shaped data → passes (schema arg wins)", async () => {
+    // Model follows SchemaA (the correct one)
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        return { id: "abc", score: 42 } as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      "extract data",
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+
+    expect(result.data).toEqual({ id: "abc", score: 42 });
+    expect(result.attempts).toBe(1);
+  });
+
+  it("model returns SchemaB-shaped data (follows systemPrompt) → fails validation", async () => {
+    // Model followed systemPrompt's schema B instead of schema arg
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        return { username: "alice", level: 5 } as T;
+      },
+    };
+
+    await expect(
+      generate(
+        model,
+        { jsonSchema: SchemaA },
+        "extract data",
+        { systemPrompt: `You are helpful. ${SchemaBDescription}`, maxRetries: 1 }
+      )
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("model returns SchemaB-shaped data — retries exhaust before passing", async () => {
+    let calls = 0;
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        calls++;
+        // Always returns SchemaB shape — never satisfies SchemaA validation
+        return { username: "alice", level: calls } as T;
+      },
+    };
+
+    await expect(
+      generate(
+        model,
+        { jsonSchema: SchemaA },
+        "extract data",
+        { systemPrompt: `You are helpful. ${SchemaBDescription}`, maxRetries: 3 }
+      )
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+
+    expect(calls).toBe(3); // all 3 retries burned
+  });
+
+  it("model returns partial SchemaA data missing required field → fails validation", async () => {
+    // Model returned only 'id', missing required 'score'
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        return { id: "abc" } as T; // score missing
+      },
+    };
+
+    await expect(
+      generate(
+        model,
+        { jsonSchema: SchemaA },
+        "extract data",
+        { maxRetries: 1 }
+      )
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+});
+
+// ─── Per-backend — real API calls, skipped when key not in .env ──────────────
+
+const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
+const hasOpenAI    = false; // OpenAI quota exceeded — re-enable when credits added
+const hasGroq      = !!process.env.GROQ_API_KEY;
+
+describe("Schema priority — Anthropic backend (real API)", () => {
+  it.skipIf(!hasAnthropic)("schema arg enforced: returns SchemaA-shaped data", async () => {
+    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      'Return an object with id="abc" and score=42.',
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+  }, 30_000);
+
+  it.skipIf(!hasAnthropic)("schema arg enforced: SchemaB prompt still validated against SchemaA — retries and passes", async () => {
+    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+    // Prompt mentions SchemaB shape but schema arg is SchemaA — model should follow SchemaA
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      'Return a JSON object with username="alice" and level=5.',
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+    // Validation enforces SchemaA — result must have id+score regardless of prompt wording
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+    console.log("[anthropic real] schema priority result:", result.data, "attempts:", result.attempts);
+  }, 30_000);
+});
+
+describe("Schema priority — OpenAI backend (real API)", () => {
+  it.skipIf(!hasOpenAI)("schema arg enforced: returns SchemaA-shaped data", async () => {
+    const model = openai({ model: "gpt-4o-mini" });
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      'Return an object with id="abc" and score=42.',
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+    console.log("[openai real] schema priority result:", result.data, "attempts:", result.attempts);
+  }, 30_000);
+
+  it.skipIf(!hasOpenAI)("schema arg enforced: SchemaB prompt still validated against SchemaA", async () => {
+    const model = openai({ model: "gpt-4o-mini" });
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      'Return a JSON object with username="bob" and level=3.',
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+    console.log("[openai real] conflicting prompt result:", result.data, "attempts:", result.attempts);
+  }, 30_000);
+});
+
+describe("Schema priority — Groq backend (real API)", () => {
+  it.skipIf(!hasGroq)("schema arg enforced: returns SchemaA-shaped data", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      'Return an object with id="abc" and score=42.',
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+    console.log("[groq real] schema priority result:", result.data, "attempts:", result.attempts);
+  }, 30_000);
+
+  it.skipIf(!hasGroq)("conflict: Groq follows user prompt over schema — exhausts retries", async () => {
+    // Groq/llama prioritises the user message over the schema injection in the system prompt.
+    // When they conflict, the model keeps returning SchemaB-shaped output, failing SchemaA
+    // validation every time — unlike Anthropic which remaps field names to match the schema.
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    await expect(
+      generate(
+        model,
+        { jsonSchema: SchemaA },
+        'Return a JSON object with username="carol" and level=8.',
+        { systemPrompt: `You are helpful. ${SchemaBDescription}`, maxRetries: 3 }
+      )
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+    console.log("[groq real] conflict: MaxRetriesExceededError as expected — Groq followed user prompt, not schema arg");
+  }, 30_000);
+});
+
+describe("Schema priority — Ollama backend (real API)", () => {
+  const hasOllama = true;
+  const ollamaModel = process.env.OLLAMA_MODEL ?? "nemotron-3-super:cloud";
+
+  it.skipIf(!hasOllama)("schema arg enforced: returns SchemaA-shaped data", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      'Return an object with id="abc" and score=42.',
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+    console.log("[ollama real] schema priority result:", result.data, "attempts:", result.attempts);
+  }, 120_000);
+
+  it.skipIf(!hasOllama)("schema arg enforced: SchemaB prompt still produces SchemaA-shaped data (constrained decoding)", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    // Prompt explicitly asks for SchemaB shape — Ollama constrained decoding should ignore it
+    const result = await generate(
+      model,
+      { jsonSchema: SchemaA },
+      'Return a JSON object with username="dave" and level=2.',
+      { systemPrompt: `You are helpful. ${SchemaBDescription}` }
+    );
+    // SchemaA must win — id and score required, username/level must not appear
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+    expect((result.data as any).username).toBeUndefined();
+    expect((result.data as any).level).toBeUndefined();
+    console.log("[ollama real] conflicting prompt result:", result.data, "attempts:", result.attempts);
+  }, 120_000);
+});
+
+describe("Schema priority — Ollama backend", () => {
+  it("schema arg enforced: SchemaA-shaped response passes", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: { content: JSON.stringify({ id: "x4", score: 33 }) } }),
+    }));
+    const model = ollama({ model: "llama3" });
+    const result = await generate(model, { jsonSchema: SchemaA }, "extract", {
+      systemPrompt: `You are helpful. ${SchemaBDescription}`,
+    });
+    expect(result.data).toMatchObject({ id: expect.any(String), score: expect.any(Number) });
+  });
+
+  it("schema arg enforced: SchemaB-shaped response fails validation", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ message: { content: JSON.stringify({ username: "dave", level: 2 }) } }),
+    }));
+    const model = ollama({ model: "llama3" });
+    await expect(
+      generate(model, { jsonSchema: SchemaA }, "extract", {
+        systemPrompt: `You are helpful. ${SchemaBDescription}`,
+        maxRetries: 1,
+      })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+});

--- a/tests/xml-rules.test.ts
+++ b/tests/xml-rules.test.ts
@@ -1,0 +1,459 @@
+/**
+ * One test-pair per documented XML template rule (README "Template rules").
+ * Each rule gets a "follows" test (correct usage, expected outcome) and a
+ * "violates" test (what actually happens when the rule is broken — either a
+ * thrown error, or a silently wrong/undesired result, matching the real
+ * behavior documented for that rule).
+ */
+import { describe, it, expect, vi } from "vitest";
+import { generate } from "../src/core/generate.js";
+import { buildStructuredPrompt } from "../src/core/schema.js";
+import { xmlType } from "../src/core/xml.js";
+import { ollama } from "../src/backends/ollama.js";
+import { groq } from "../src/backends/groq.js";
+import { MaxRetriesExceededError } from "../src/types.js";
+import type { ShapecraftModel, SchemaInput } from "../src/types.js";
+
+const hasOllama = !!process.env.OLLAMA_MODEL;
+const ollamaModel = process.env.OLLAMA_MODEL ?? "nemotron-3-super:cloud";
+const hasGroq = !!process.env.GROQ_API_KEY;
+
+function mockBackend(responses: string[] | (() => string)): ShapecraftModel {
+  let calls = 0;
+  const spy = vi.fn();
+  return {
+    id: "mock",
+    guaranteeLevel: "best-effort",
+    async generate<T>(prompt: string, schema: any, systemPrompt?: string): Promise<T> {
+      // mimic a real backend: build the prompt before "calling the API" —
+      // this is what makes template validation fire before any network call
+      buildStructuredPrompt(prompt, schema, systemPrompt);
+      spy();
+      const raw = typeof responses === "function" ? responses() : responses[Math.min(calls, responses.length - 1)];
+      calls++;
+      return raw as T;
+    },
+    // exposed for assertions
+    // @ts-expect-error test-only field
+    __spy: spy,
+  };
+}
+
+// ─── Rule 1 — only {string}/{number}/{boolean} are valid placeholder tokens ───
+
+describe("Rule 1: placeholder tokens must be exactly {string}/{number}/{boolean}", () => {
+  it("FOLLOWS: template using only recognized tokens succeeds", async () => {
+    const model = mockBackend(['<book id="BK-1"><title>Clean Code</title></book>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<book id="${xmlType.string}"><title>${xmlType.string}</title></book>` } },
+      "Get book"
+    );
+    expect(result.data).toContain("<title>Clean Code</title>");
+  });
+
+  it("VIOLATES: {integer} is not a recognized token — throws before any model call", async () => {
+    const model = mockBackend(['<book edition="2"><title>X</title></book>']);
+    await expect(
+      generate(model, { xml: { template: `<book edition="{integer}"><title>{string}</title></book>` } }, "Get book")
+    ).rejects.toThrow(/Invalid placeholder.*\{integer\}/);
+    // @ts-expect-error test-only field
+    expect(model.__spy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Rule 2 — unbraced text is a literal, best-effort preserved ──────────────
+
+describe("Rule 2: unbraced text is a literal (best-effort, not guaranteed)", () => {
+  it("FOLLOWS: model leaves the literal alone", async () => {
+    const model = mockBackend(['<order status="pending"><id>ORD-1</id></order>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<order status="pending"><id>${xmlType.string}</id></order>` } },
+      "Get order"
+    );
+    expect(result.data).toContain('status="pending"');
+  });
+
+  it("VIOLATES: without enforceLiterals, a model that rewrites the literal is not caught", async () => {
+    // simulates an LLM "helpfully" changing a literal it wasn't supposed to touch
+    const model = mockBackend(['<order status="shipped"><id>ORD-1</id></order>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<order status="pending"><id>${xmlType.string}</id></order>` } },
+      "Get order"
+    );
+    // the library has no way to know "shipped" is wrong — it passes through
+    expect(result.data).toContain('status="shipped"');
+    expect(result.data).not.toContain('status="pending"');
+  });
+});
+
+// ─── Rule 3 — attributes follow the same placeholder/literal rules ───────────
+
+describe("Rule 3: attributes follow the same placeholder rules as element text", () => {
+  it("FOLLOWS: attribute placeholder uses a recognized token", async () => {
+    const model = mockBackend(['<book available="true"><title>X</title></book>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<book available="${xmlType.boolean}"><title>${xmlType.string}</title></book>` } },
+      "Get book"
+    );
+    expect(result.data).toContain('available="true"');
+  });
+
+  it("VIOLATES: garbled attribute placeholder throws before any model call", async () => {
+    const model = mockBackend(['<book id="X1"><title>X</title></book>']);
+    await expect(
+      generate(model, { xml: { template: `<book id="{identifier}"><title>{string}</title></book>` } }, "Get book")
+    ).rejects.toThrow(/\{identifier\}/);
+    // @ts-expect-error test-only field
+    expect(model.__spy).not.toHaveBeenCalled();
+  });
+});
+
+// ─── Rule 4 — namespaces/prefixes are literal text ───────────────────────────
+
+describe("Rule 4: namespace prefixes are literal text, reproduced verbatim", () => {
+  it("FOLLOWS: xmlns declared and xs: prefix used consistently", async () => {
+    const model = mockBackend([
+      '<xs:book xmlns:xs="http://example.com"><xs:title>Clean Code</xs:title></xs:book>',
+    ]);
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<xs:book xmlns:xs="http://example.com"><xs:title>${xmlType.string}</xs:title></xs:book>`,
+        },
+      },
+      "Get book"
+    );
+    expect(result.data).toContain('xmlns:xs="http://example.com"');
+  });
+
+  it("VIOLATES: xs: prefix used without declaring xmlns:xs — not caught, still 'succeeds'", async () => {
+    // no xmlns:xs anywhere — not proper namespace-qualified XML, but basic
+    // XML well-formedness doesn't require namespace declarations, so nothing
+    // in the library flags it
+    const model = mockBackend(["<xs:book><xs:title>Clean Code</xs:title></xs:book>"]);
+    const result = await generate(
+      model,
+      { xml: { template: `<xs:book><xs:title>${xmlType.string}</xs:title></xs:book>` } },
+      "Get book"
+    );
+    expect(result.data).not.toContain("xmlns:xs");
+    expect(result.data).toContain("<xs:book>"); // "succeeded" despite the missing declaration
+  });
+});
+
+// ─── Rule 5 — repeated elements: show one example, use `arrays` for parse:true ─
+
+describe("Rule 5: repeated elements need `arrays` to guarantee array shape under parse:true", () => {
+  it("FOLLOWS: arrays option forces an array even conceptually for repeats", async () => {
+    const model = mockBackend(["<library><book><title>A</title></book><book><title>B</title></book></library>"]);
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<library><book><title>${xmlType.string}</title></book></library>`,
+          arrays: ["book"],
+          parse: true,
+        },
+      },
+      "Get library"
+    );
+    expect(Array.isArray((result.data as any).book)).toBe(true);
+    expect((result.data as any).book).toHaveLength(2);
+  });
+
+  it("VIOLATES: without `arrays`, a single result collapses to a plain object, not an array", async () => {
+    const model = mockBackend(["<library><book><title>A</title></book></library>"]);
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<library><book><title>${xmlType.string}</title></book></library>`,
+          // no `arrays: ["book"]` — the gotcha
+          parse: true,
+        },
+      },
+      "Get library"
+    );
+    // downstream code assuming an array (e.g. .map()) would break here
+    expect(Array.isArray((result.data as any).book)).toBe(false);
+  });
+});
+
+// ─── Rule 6 — required nodes must be present AND non-empty ───────────────────
+
+describe("Rule 6: required nodes must be present and non-empty, or the call retries", () => {
+  it("FOLLOWS: required node present and non-empty succeeds on first attempt", async () => {
+    const model = mockBackend(['<order><items>widget</items></order>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<order><items>${xmlType.string}</items></order>`, required: ["items"] } },
+      "Get order"
+    );
+    expect(result.attempts).toBe(1);
+  });
+
+  it("VIOLATES: required node always empty — exhausts retries", async () => {
+    const model = mockBackend(() => "<order><items></items></order>");
+    await expect(
+      generate(
+        model,
+        { xml: { template: `<order><items>${xmlType.string}</items></order>`, required: ["items"] } },
+        "Get order",
+        { maxRetries: 2 }
+      )
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+});
+
+// ─── Rule 7 — enforceLiterals guarantees literal fidelity, deterministically ──
+
+describe("Rule 7: enforceLiterals forces literal fidelity even when the model changes it", () => {
+  it("FOLLOWS: enforceLiterals: true corrects a model-altered literal", async () => {
+    const model = mockBackend(['<catalog totalBooks="99"><title>The Road</title></catalog>']);
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<catalog totalBooks="90"><title>${xmlType.string}</title></catalog>`,
+          enforceLiterals: true,
+        },
+      },
+      "Get catalog"
+    );
+    expect(result.data).toContain('totalBooks="90"');
+  });
+
+  it("VIOLATES: forgetting enforceLiterals lets a critical literal silently drift", async () => {
+    const model = mockBackend(['<catalog totalBooks="99"><title>The Road</title></catalog>']);
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<catalog totalBooks="90"><title>${xmlType.string}</title></catalog>`,
+          // enforceLiterals not set — the "90" constant silently becomes "99"
+        },
+      },
+      "Get catalog"
+    );
+    expect(result.data).toContain('totalBooks="99"');
+    expect(result.data).not.toContain('totalBooks="90"');
+  });
+});
+
+// ─── Rule 8 — <?xml ...?> prolog is stripped by default ──────────────────────
+
+describe("Rule 8: the XML prolog is stripped by default; prolog: true keeps it", () => {
+  it("FOLLOWS: prolog: true keeps a model-added declaration", async () => {
+    const model = mockBackend(['<?xml version="1.0"?>\n<book><title>X</title></book>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<book><title>${xmlType.string}</title></book>`, prolog: true } },
+      "Get book"
+    );
+    expect(result.data).toMatch(/^<\?xml/);
+  });
+
+  it("VIOLATES: expecting the prolog to survive by default — it doesn't", async () => {
+    const model = mockBackend(['<?xml version="1.0"?>\n<book><title>X</title></book>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<book><title>${xmlType.string}</title></book>` } }, // no prolog: true
+      "Get book"
+    );
+    expect(result.data).not.toContain("<?xml");
+  });
+});
+
+// ─── Rule 9 — parse: true returns an object; omitting it returns a string ────
+
+describe("Rule 9: parse: true returns an object; the default is a string", () => {
+  it("FOLLOWS: parse: true gives a typed object", async () => {
+    const model = mockBackend(['<person><name>John</name><age>35</age></person>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<person><name>${xmlType.string}</name><age>${xmlType.number}</age></person>`, parse: true } },
+      "Get person"
+    );
+    expect(typeof result.data).toBe("object");
+    expect((result.data as any).name).toBe("John");
+  });
+
+  it("VIOLATES: forgetting parse: true — treating the string result as an object", async () => {
+    const model = mockBackend(['<person><name>John</name><age>35</age></person>']);
+    const result = await generate(
+      model,
+      { xml: { template: `<person><name>${xmlType.string}</name><age>${xmlType.number}</age></person>` } }, // no parse: true
+      "Get person"
+    );
+    expect(typeof result.data).toBe("string");
+    // the classic mistake: this is undefined, not "John", because result.data is a string
+    expect((result.data as any).name).toBeUndefined();
+  });
+});
+
+// ─── Real Ollama backend — same rules, a real model instead of mocks ─────────
+
+describe("XML rules — Ollama backend (real API)", () => {
+  it.skipIf(!hasOllama)("Rule 1: garbled placeholder throws before any Ollama call", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    await expect(
+      generate(
+        model,
+        { xml: { template: `<book edition="{integer}"><title>{string}</title></book>` } },
+        "Extract: Clean Code by Robert Martin."
+      )
+    ).rejects.toThrow(/Invalid placeholder.*\{integer\}/);
+  }, 30_000);
+
+  it.skipIf(!hasOllama)("Rule 5: arrays option gives a real multi-item array under parse:true", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<library><book><title>${xmlType.string}</title></book></library>`,
+          arrays: ["book"],
+          parse: true,
+        },
+      },
+      "Library has two books: 'Clean Code' and 'The Pragmatic Programmer'."
+    );
+    expect(Array.isArray((result.data as any).book)).toBe(true);
+    console.log("[ollama] rule 5 result:", result.data);
+  }, 30_000);
+
+  it.skipIf(!hasOllama)("Rule 6: required node satisfied on real extraction", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<order><items>${xmlType.string}</items></order>`,
+          required: ["items"],
+        },
+      },
+      "Order contains: a widget."
+    );
+    expect(result.data).toContain("<items>");
+    console.log("[ollama] rule 6 result:", result.data, "attempts:", result.attempts);
+  }, 30_000);
+
+  it.skipIf(!hasOllama)("Rule 7: enforceLiterals corrects real model drift on an unbraced literal", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<catalog updated="some-randome-date-after-2026"><title>${xmlType.string}</title></catalog>`,
+          enforceLiterals: true,
+        },
+      },
+      "Fiction wing update, dated 2024-05-01. Title: The Road."
+    );
+    expect(result.data).toContain('updated="some-randome-date-after-2026"');
+    console.log("[ollama] rule 7 result:", result.data);
+  }, 30_000);
+
+  it.skipIf(!hasOllama)("Rule 9: parse: true returns a real typed object", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<person><name>${xmlType.string}</name><age>${xmlType.number}</age></person>`,
+          parse: true,
+        },
+      },
+      "Extract: John Doe, 35 years old."
+    );
+    expect(typeof result.data).toBe("object");
+    expect((result.data as any).name).toBeTruthy();
+    console.log("[ollama] rule 9 result:", result.data);
+  }, 30_000);
+});
+
+// ─── Real Groq backend — same rules, a real model instead of mocks ───────────
+
+describe("XML rules — Groq backend (real API)", () => {
+  it.skipIf(!hasGroq)("Rule 1: garbled placeholder throws before any Groq call", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    await expect(
+      generate(
+        model,
+        { xml: { template: `<book edition="{integer}"><title>{string}</title></book>` } },
+        "Extract: Clean Code by Robert Martin."
+      )
+    ).rejects.toThrow(/Invalid placeholder.*\{integer\}/);
+  }, 30_000);
+
+  it.skipIf(!hasGroq)("Rule 5: arrays option gives a real multi-item array under parse:true", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<library><book><title>${xmlType.string}</title></book></library>`,
+          arrays: ["book"],
+          parse: true,
+        },
+      },
+      "Library has two books: 'Clean Code' and 'The Pragmatic Programmer'."
+    );
+    expect(Array.isArray((result.data as any).book)).toBe(true);
+    console.log("[groq] rule 5 result:", result.data);
+  }, 30_000);
+
+  it.skipIf(!hasGroq)("Rule 6: required node satisfied on real extraction", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<order><items>${xmlType.string}</items></order>`,
+          required: ["items"],
+        },
+      },
+      "Order contains: a widget."
+    );
+    expect(result.data).toContain("<items>");
+    console.log("[groq] rule 6 result:", result.data, "attempts:", result.attempts);
+  }, 30_000);
+
+  it.skipIf(!hasGroq)("Rule 7: enforceLiterals corrects real model drift on an unbraced literal", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<catalog updated="some-randome-date-after-2026"><title>${xmlType.string}</title></catalog>`,
+          enforceLiterals: true,
+        },
+      },
+      "Fiction wing update, dated 2024-05-01. Title: The Road."
+    );
+    expect(result.data).toContain('updated="some-randome-date-after-2026"');
+    console.log("[groq] rule 7 result:", result.data);
+  }, 30_000);
+
+  it.skipIf(!hasGroq)("Rule 9: parse: true returns a real typed object", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: `<person><name>${xmlType.string}</name><age>${xmlType.number}</age></person>`,
+          parse: true,
+        },
+      },
+      "Extract: John Doe, 35 years old."
+    );
+    expect(typeof result.data).toBe("object");
+    expect((result.data as any).name).toBeTruthy();
+    console.log("[groq] rule 9 result:", result.data);
+  }, 30_000);
+});

--- a/tests/xml.test.ts
+++ b/tests/xml.test.ts
@@ -1,56 +1,21 @@
 import { describe, it, expect } from "vitest";
 import { generate } from "../src/core/generate.js";
-import { xmlObjectToTemplate, parseXml, validateXmlOutput, buildXmlSystemPrompt } from "../src/core/xml.js";
+import { parseXml, validateXmlOutput, cleanXml, buildXmlSystemPrompt } from "../src/core/xml.js";
 import { anthropic } from "../src/backends/anthropic.js";
 import { groq } from "../src/backends/groq.js";
 import { MaxRetriesExceededError, SchemaViolationError } from "../src/types.js";
-import type { XmlObjectInput, XmlTemplateInput, ShapecraftModel } from "../src/types.js";
+import type { XmlInput, ShapecraftModel } from "../src/types.js";
 
 const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
 const hasGroq = !!process.env.GROQ_API_KEY;
 
-// ─── xmlObjectToTemplate ─────────────────────────────────────────────────────
+// ─── cleanXml ────────────────────────────────────────────────────────────────
 
-describe("xmlObjectToTemplate", () => {
-  it("flat fields", () => {
-    const input: XmlObjectInput = {
-      xmlObject: { root: "book", fields: { title: "string", author: "string" } },
-    };
-    const tmpl = xmlObjectToTemplate(input);
-    expect(tmpl).toContain("<book>");
-    expect(tmpl).toContain("<title>{string}</title>");
-    expect(tmpl).toContain("<author>{string}</author>");
-    expect(tmpl).toContain("</book>");
-  });
-
-  it("nested object field", () => {
-    const input: XmlObjectInput = {
-      xmlObject: {
-        root: "order",
-        fields: {
-          id: "string",
-          address: { type: "object", fields: { city: "string", zip: "string" } },
-        },
-      },
-    };
-    const tmpl = xmlObjectToTemplate(input);
-    expect(tmpl).toContain("<address>");
-    expect(tmpl).toContain("<city>{string}</city>");
-  });
-
-  it("array field", () => {
-    const input: XmlObjectInput = {
-      xmlObject: {
-        root: "library",
-        fields: {
-          books: { type: "array", items: { title: "string", year: "number" } },
-        },
-      },
-    };
-    const tmpl = xmlObjectToTemplate(input);
-    expect(tmpl).toContain("<books>");
-    expect(tmpl).toContain("<item>");
-    expect(tmpl).toContain("<year>{number}</year>");
+describe("cleanXml", () => {
+  it("strips markdown code fences and whitespace", () => {
+    expect(cleanXml("```xml\n<book><title>Test</title></book>\n```")).toBe(
+      "<book><title>Test</title></book>"
+    );
   });
 });
 
@@ -58,171 +23,96 @@ describe("xmlObjectToTemplate", () => {
 
 describe("parseXml", () => {
   it("parses flat XML", () => {
-    const raw = "<book><title>XML in Practice</title><author>Jane Smith</author></book>";
-    const result = parseXml(raw);
+    const result = parseXml("<book><title>XML in Practice</title><author>Jane Smith</author></book>");
     expect(result).toMatchObject({ book: { title: "XML in Practice", author: "Jane Smith" } });
   });
 
   it("parses nested XML", () => {
-    const raw = "<order><id>42</id><address><city>NYC</city><zip>10001</zip></address></order>";
-    const result = parseXml(raw);
+    const result = parseXml("<order><id>42</id><address><city>NYC</city></address></order>");
     expect((result as any).order.address.city).toBe("NYC");
   });
 
-  it("strips markdown code fences", () => {
-    const raw = "```xml\n<book><title>Test</title></book>\n```";
-    const result = parseXml(raw);
-    expect((result as any).book.title).toBe("Test");
+  it("captures attributes", () => {
+    const result = parseXml('<book id="123"><title>Test</title></book>');
+    expect((result as any).book["@_id"]).toBe("123");
   });
 
-  it("normalizes array paths", () => {
-    const raw = "<library><book><title>A</title></book></library>";
-    const result = parseXml(raw, ["book"]);
+  it("normalizes named nodes into arrays", () => {
+    const result = parseXml("<library><book><title>A</title></book></library>", ["book"]);
     expect(Array.isArray((result as any).library.book)).toBe(true);
-  });
-
-  it("lenient parser handles unclosed tags as empty node", () => {
-    const result = parseXml("<unclosed>");
-    expect(result).toMatchObject({ unclosed: "" });
-  });
-});
-
-// ─── validateXmlOutput ───────────────────────────────────────────────────────
-
-describe("validateXmlOutput", () => {
-  it("extracts root and coerces types", () => {
-    const parsed = { book: { title: "Test", pages: "320" } };
-    const schema: XmlObjectInput = {
-      xmlObject: { root: "book", fields: { title: "string", pages: "number" } },
-    };
-    const result = validateXmlOutput(parsed, schema) as any;
-    expect(result.title).toBe("Test");
-    expect(result.pages).toBe(320);
-  });
-
-  it("throws on missing required field", () => {
-    const parsed = { book: { title: "Test" } };
-    const schema: XmlObjectInput = {
-      xmlObject: { root: "book", fields: { title: "string", author: "string" } },
-    };
-    expect(() => validateXmlOutput(parsed, schema)).toThrow(SchemaViolationError);
-  });
-
-  it("throws on missing root element", () => {
-    const parsed = { person: { name: "John" } };
-    const schema: XmlObjectInput = {
-      xmlObject: { root: "book", fields: { title: "string" } },
-    };
-    expect(() => validateXmlOutput(parsed, schema)).toThrow();
-  });
-
-  it("unwraps <item>-wrapped array of objects with nested fields", () => {
-    const parsed = {
-      company: {
-        name: "Globex",
-        founded: "1989",
-        departments: {
-          item: [
-            { name: "Engineering", headcount: "42", lead: { fullName: "Jane Roe", yearsExperience: "12" } },
-            { name: "Design", headcount: "8", lead: { fullName: "Max Vane", yearsExperience: "7" } },
-          ],
-        },
-      },
-    };
-    const schema: XmlObjectInput = {
-      xmlObject: {
-        root: "company",
-        fields: {
-          name: "string",
-          founded: "number",
-          departments: {
-            type: "array",
-            items: {
-              name: "string",
-              headcount: "number",
-              lead: { type: "object", fields: { fullName: "string", yearsExperience: "number" } },
-            },
-          },
-        },
-      },
-    };
-    const result = validateXmlOutput(parsed, schema) as any;
-    expect(Array.isArray(result.departments)).toBe(true);
-    expect(result.departments).toHaveLength(2);
-    expect(result.founded).toBe(1989);
-    expect(result.departments[0].headcount).toBe(42);
-    expect(result.departments[0].lead.yearsExperience).toBe(12);
-  });
-
-  it("single-item array still yields a one-element array", () => {
-    const parsed = { company: { tags: { item: { label: "solo" } } } };
-    const schema: XmlObjectInput = {
-      xmlObject: {
-        root: "company",
-        fields: { tags: { type: "array", items: { label: "string" } } },
-      },
-    };
-    const result = validateXmlOutput(parsed, schema) as any;
-    expect(Array.isArray(result.tags)).toBe(true);
-    expect(result.tags).toHaveLength(1);
-    expect(result.tags[0].label).toBe("solo");
-  });
-
-  it("xmlTemplate returns root element", () => {
-    const parsed = { book: { title: "Test", author: "Jane" } };
-    const schema: XmlTemplateInput = { xmlTemplate: "<book><title>{string}</title></book>" };
-    const result = validateXmlOutput(parsed, schema) as any;
-    expect(result.title).toBe("Test");
   });
 });
 
 // ─── buildXmlSystemPrompt ────────────────────────────────────────────────────
 
 describe("buildXmlSystemPrompt", () => {
-  it("includes template structure for xmlObject", () => {
-    const schema: XmlObjectInput = {
-      xmlObject: { root: "book", fields: { title: "string" } },
-    };
-    const prompt = buildXmlSystemPrompt(schema);
-    expect(prompt).toContain("<book>");
-    expect(prompt).toContain("{string}");
-  });
-
-  it("uses template string directly for xmlTemplate", () => {
-    const schema: XmlTemplateInput = { xmlTemplate: "<person><name>{string}</name></person>" };
+  it("wraps the template with instructions", () => {
+    const schema: XmlInput = { xml: { template: "<person><name>{string}</name></person>" } };
     const prompt = buildXmlSystemPrompt(schema);
     expect(prompt).toContain("<person>");
+    expect(prompt).toContain("valid XML");
+  });
+});
+
+// ─── validateXmlOutput — required nodes ──────────────────────────────────────
+
+describe("validateXmlOutput — required nodes", () => {
+  const schema: XmlInput = {
+    xml: { template: "<catalog><books><book>{string}</book></books></catalog>", required: ["books"] },
+  };
+
+  it("passes when the required node is present and non-empty", () => {
+    const parsed = parseXml("<catalog><books><book>Clean Code</book></books></catalog>");
+    expect(() => validateXmlOutput(parsed, schema)).not.toThrow();
+  });
+
+  it("throws when the required node is missing", () => {
+    const parsed = parseXml("<catalog><title>No books here</title></catalog>");
+    expect(() => validateXmlOutput(parsed, schema)).toThrow(SchemaViolationError);
+  });
+
+  it("throws when the required node is present but empty", () => {
+    const parsed = parseXml("<catalog><books></books></catalog>");
+    expect(() => validateXmlOutput(parsed, schema)).toThrow(SchemaViolationError);
+  });
+
+  it("finds a required node at any depth", () => {
+    const deep: XmlInput = { xml: { template: "<a><b><c>{string}</c></b></a>", required: ["c"] } };
+    const parsed = parseXml("<a><b><c>value</c></b></a>");
+    expect(() => validateXmlOutput(parsed, deep)).not.toThrow();
+  });
+
+  it("no required list → no presence check", () => {
+    const loose: XmlInput = { xml: { template: "<book><title>{string}</title></book>" } };
+    const parsed = parseXml("<book></book>");
+    expect(() => validateXmlOutput(parsed, loose)).not.toThrow();
   });
 });
 
 // ─── generate() with mock model ──────────────────────────────────────────────
 
 describe("generate() with XML schema — mock model", () => {
-  it("xmlObject: parses and validates LLM XML output", async () => {
+  it("default returns the validated XML string", async () => {
     const model: ShapecraftModel = {
       id: "mock",
       guaranteeLevel: "best-effort",
       async generate<T>(): Promise<T> {
-        return "<book><title>XML in Practice</title><author>Jane Smith</author><pages>320</pages></book>" as T;
+        return "<book><title>Clean Code</title></book>" as T;
       },
     };
 
     const result = await generate(
       model,
-      {
-        xmlObject: {
-          root: "book",
-          fields: { title: "string", author: "string", pages: "number" },
-        },
-      },
-      "Extract book info"
+      { xml: { template: "<book><title>{string}</title></book>" } },
+      "Get book"
     );
 
-    expect(result.data).toMatchObject({ title: "XML in Practice", author: "Jane Smith", pages: 320 });
+    expect(typeof result.data).toBe("string");
+    expect(result.data).toContain("<title>Clean Code</title>");
     expect(result.attempts).toBe(1);
   });
 
-  it("xmlTemplate: parses LLM XML output and returns root element", async () => {
+  it("parse: true returns the parsed root element", async () => {
     const model: ShapecraftModel = {
       id: "mock",
       guaranteeLevel: "best-effort",
@@ -233,126 +123,139 @@ describe("generate() with XML schema — mock model", () => {
 
     const result = await generate(
       model,
-      { xmlTemplate: "<person><name>{string}</name><age>{number}</age></person>" },
-      "Extract person info"
+      { xml: { template: "<person><name>{string}</name><age>{number}</age></person>", parse: true } },
+      "Get person"
     );
 
     expect((result.data as any).name).toBe("Alice");
   });
 
-  it("retries on invalid XML output", async () => {
-    let calls = 0;
+  it("attributes survive in the default XML string", async () => {
     const model: ShapecraftModel = {
       id: "mock",
       guaranteeLevel: "best-effort",
       async generate<T>(): Promise<T> {
-        calls++;
-        if (calls < 2) return "not xml at all" as T;
-        return "<book><title>Valid</title><author>Author</author></book>" as T;
+        return '<book id="BK-1" available="true"><title>Clean Code</title></book>' as T;
       },
     };
 
     const result = await generate(
       model,
-      { xmlObject: { root: "book", fields: { title: "string", author: "string" } } },
+      { xml: { template: '<book id="{string}" available="{boolean}"><title>{string}</title></book>' } },
       "Get book"
     );
 
-    expect(result.attempts).toBe(2);
-    expect((result.data as any).title).toBe("Valid");
+    expect(result.data).toContain('id="BK-1"');
+    expect(result.data).toContain('available="true"');
   });
 
-  it("exhausts retries on consistently bad output", async () => {
+  it("required: missing node exhausts retries", async () => {
     const model: ShapecraftModel = {
       id: "mock",
       guaranteeLevel: "best-effort",
       async generate<T>(): Promise<T> {
-        return "<person><name>Alice</name></person>" as T;
+        return "<catalog><title>No books</title></catalog>" as T;
       },
     };
 
     await expect(
       generate(
         model,
-        { xmlObject: { root: "book", fields: { title: "string", author: "string" } } },
-        "Get book",
+        { xml: { template: "<catalog><books>{string}</books></catalog>", required: ["books"] } },
+        "Build catalog",
         { maxRetries: 2 }
       )
     ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("required: retries then passes once the node appears", async () => {
+    let calls = 0;
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        calls++;
+        if (calls < 2) return "<catalog><title>nope</title></catalog>" as T;
+        return "<catalog><books><book>Clean Code</book></books></catalog>" as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xml: { template: "<catalog><books><book>{string}</book></books></catalog>", required: ["books"] } },
+      "Build catalog"
+    );
+
+    expect(result.attempts).toBe(2);
+    expect(result.data).toContain("<book>Clean Code</book>");
+  });
+
+  it("retries on malformed (structurally invalid) XML output", async () => {
+    let calls = 0;
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        calls++;
+        // mismatched tags — fast-xml-parser throws on this
+        if (calls < 2) return "<book><title>broken</author></book>" as T;
+        return "<book><title>Valid</title></book>" as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xml: { template: "<book><title>{string}</title></book>" } },
+      "Get book"
+    );
+
+    expect(result.attempts).toBe(2);
+    expect(result.data).toContain("<title>Valid</title>");
   });
 });
 
 // ─── Real API tests ───────────────────────────────────────────────────────────
 
 describe("XML — Anthropic backend (real API)", () => {
-  it.skipIf(!hasAnthropic)("xmlObject: flat book extraction", async () => {
+  it.skipIf(!hasAnthropic)("returns XML string by default", async () => {
     const model = anthropic({ model: "claude-haiku-4-5-20251001" });
     const result = await generate(
       model,
-      { xmlObject: { root: "book", fields: { title: "string", author: "string", year: "number" } } },
+      { xml: { template: `<book>\n  <title>{string}</title>\n  <author>{string}</author>\n  <year>{number}</year>\n</book>` } },
       'Extract book info: "XML in Practice" by Jane Smith, published in 2003.'
     );
-    expect((result.data as any).title).toContain("XML");
-    expect((result.data as any).year).toBe(2003);
-    console.log("[anthropic] xmlObject result:", result.data);
+    expect(typeof result.data).toBe("string");
+    expect(result.data).toContain("<title>");
+    console.log("[anthropic] xml string:", result.data);
   }, 30_000);
 
-  it.skipIf(!hasAnthropic)("xmlTemplate: person extraction", async () => {
+  it.skipIf(!hasAnthropic)("parse: true returns typed object", async () => {
     const model = anthropic({ model: "claude-haiku-4-5-20251001" });
     const result = await generate(
       model,
-      {
-        xmlTemplate: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n  <city>{string}</city>\n</person>`,
-      },
-      "Extract: John Doe, 35 years old, lives in San Francisco."
+      { xml: { template: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>`, parse: true } },
+      "Extract: John Doe, 35 years old."
     );
     expect((result.data as any).name).toContain("John");
-    expect((result.data as any).age).toBe(35);
-    console.log("[anthropic] xmlTemplate result:", result.data);
-  }, 30_000);
-
-  it.skipIf(!hasAnthropic)("xmlObject: nested address", async () => {
-    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
-    const result = await generate(
-      model,
-      {
-        xmlObject: {
-          root: "order",
-          fields: {
-            id: "string",
-            address: { type: "object", fields: { city: "string", country: "string" } },
-          },
-        },
-      },
-      'Order #ORD-001, shipping to London, United Kingdom.'
-    );
-    expect((result.data as any).address.city).toBeTruthy();
-    console.log("[anthropic] nested result:", result.data);
+    console.log("[anthropic] parsed:", result.data);
   }, 30_000);
 });
 
 describe("XML — Groq backend (real API)", () => {
-  it.skipIf(!hasGroq)("xmlObject: flat extraction", async () => {
-    const model = groq({ model: "llama-3.3-70b-versatile" });
-    const result = await generate(
-      model,
-      { xmlObject: { root: "book", fields: { title: "string", author: "string" } } },
-      'Extract book: "Clean Code" by Robert C. Martin.'
-    );
-    expect((result.data as any).title).toBeTruthy();
-    console.log("[groq] xmlObject result:", result.data);
-  }, 30_000);
-
-  it.skipIf(!hasGroq)("xmlTemplate: person extraction", async () => {
+  it.skipIf(!hasGroq)("returns XML string with required node satisfied", async () => {
     const model = groq({ model: "llama-3.3-70b-versatile" });
     const result = await generate(
       model,
       {
-        xmlTemplate: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>`,
+        xml: {
+          template: `<book>\n  <title>{string}</title>\n  <author>{string}</author>\n</book>`,
+          required: ["title", "author"],
+        },
       },
-      "Extract: Sarah Connor, 29 years old."
+      'Extract book: "Clean Code" by Robert C. Martin.'
     );
-    expect((result.data as any).name).toBeTruthy();
-    console.log("[groq] xmlTemplate result:", result.data);
+    expect(result.data).toContain("<title>");
+    expect(result.data).toContain("<author>");
+    console.log("[groq] xml string:", result.data);
   }, 30_000);
 });

--- a/tests/xml.test.ts
+++ b/tests/xml.test.ts
@@ -116,6 +116,58 @@ describe("validateXmlOutput", () => {
     expect(() => validateXmlOutput(parsed, schema)).toThrow();
   });
 
+  it("unwraps <item>-wrapped array of objects with nested fields", () => {
+    const parsed = {
+      company: {
+        name: "Globex",
+        founded: "1989",
+        departments: {
+          item: [
+            { name: "Engineering", headcount: "42", lead: { fullName: "Jane Roe", yearsExperience: "12" } },
+            { name: "Design", headcount: "8", lead: { fullName: "Max Vane", yearsExperience: "7" } },
+          ],
+        },
+      },
+    };
+    const schema: XmlObjectInput = {
+      xmlObject: {
+        root: "company",
+        fields: {
+          name: "string",
+          founded: "number",
+          departments: {
+            type: "array",
+            items: {
+              name: "string",
+              headcount: "number",
+              lead: { type: "object", fields: { fullName: "string", yearsExperience: "number" } },
+            },
+          },
+        },
+      },
+    };
+    const result = validateXmlOutput(parsed, schema) as any;
+    expect(Array.isArray(result.departments)).toBe(true);
+    expect(result.departments).toHaveLength(2);
+    expect(result.founded).toBe(1989);
+    expect(result.departments[0].headcount).toBe(42);
+    expect(result.departments[0].lead.yearsExperience).toBe(12);
+  });
+
+  it("single-item array still yields a one-element array", () => {
+    const parsed = { company: { tags: { item: { label: "solo" } } } };
+    const schema: XmlObjectInput = {
+      xmlObject: {
+        root: "company",
+        fields: { tags: { type: "array", items: { label: "string" } } },
+      },
+    };
+    const result = validateXmlOutput(parsed, schema) as any;
+    expect(Array.isArray(result.tags)).toBe(true);
+    expect(result.tags).toHaveLength(1);
+    expect(result.tags[0].label).toBe("solo");
+  });
+
   it("xmlTemplate returns root element", () => {
     const parsed = { book: { title: "Test", author: "Jane" } };
     const schema: XmlTemplateInput = { xmlTemplate: "<book><title>{string}</title></book>" };

--- a/tests/xml.test.ts
+++ b/tests/xml.test.ts
@@ -1,6 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { generate } from "../src/core/generate.js";
-import { parseXml, validateXmlOutput, cleanXml, buildXmlSystemPrompt } from "../src/core/xml.js";
+import {
+  parseXml,
+  validateXmlOutput,
+  cleanXml,
+  buildXmlSystemPrompt,
+  validateXmlTemplate,
+  stripXmlProlog,
+  xmlType,
+} from "../src/core/xml.js";
 import { anthropic } from "../src/backends/anthropic.js";
 import { groq } from "../src/backends/groq.js";
 import { MaxRetriesExceededError, SchemaViolationError } from "../src/types.js";
@@ -52,6 +60,101 @@ describe("buildXmlSystemPrompt", () => {
     expect(prompt).toContain("<person>");
     expect(prompt).toContain("valid XML");
   });
+
+  it("instructs the model to preserve non-placeholder text verbatim", () => {
+    const schema: XmlInput = { xml: { template: "<person><name>{string}</name></person>" } };
+    const prompt = buildXmlSystemPrompt(schema);
+    expect(prompt).toMatch(/preserve/i);
+  });
+
+  it("throws before the model is called if the template has an invalid placeholder", () => {
+    const schema: XmlInput = { xml: { template: '<book edition="{sdasasd}"><title>{string}</title></book>' } };
+    expect(() => buildXmlSystemPrompt(schema)).toThrow(/Invalid placeholder/);
+  });
+});
+
+// ─── xmlType ─────────────────────────────────────────────────────────────────
+
+describe("xmlType", () => {
+  it("exposes the three recognized placeholder tokens", () => {
+    expect(xmlType.string).toBe("{string}");
+    expect(xmlType.number).toBe("{number}");
+    expect(xmlType.boolean).toBe("{boolean}");
+  });
+});
+
+// ─── validateXmlTemplate ──────────────────────────────────────────────────────
+
+describe("validateXmlTemplate", () => {
+  it("accepts a template using only {string}/{number}/{boolean}", () => {
+    expect(() =>
+      validateXmlTemplate(
+        '<book id="{string}" available="{boolean}"><title>{string}</title><year>{number}</year></book>'
+      )
+    ).not.toThrow();
+  });
+
+  it("accepts literal (unbraced) text — only {} content is validated", () => {
+    // this is the exact case from the bug report: a descriptive literal with
+    // no braces at all is not a placeholder and must not be flagged
+    expect(() =>
+      validateXmlTemplate('<library updated="some-randome-date-before-2026"><title>{string}</title></library>')
+    ).not.toThrow();
+  });
+
+  it("rejects a garbled placeholder word wrapped in braces", () => {
+    // edition="{sdasasd}" from the bug report
+    expect(() => validateXmlTemplate('<book edition="{sdasasd}"><title>{string}</title></book>')).toThrow(
+      /\{sdasasd\}/
+    );
+  });
+
+  it("rejects a numeric literal mistakenly wrapped in braces", () => {
+    // totalBooks="{90}" from the bug report — braces make it look like a
+    // placeholder, but "90" isn't a recognized token
+    expect(() => validateXmlTemplate('<library totalBooks="{90}"><title>{string}</title></library>')).toThrow(
+      /\{90\}/
+    );
+  });
+
+  it("rejects another garbled word — name=\"{stringgggg}\"", () => {
+    expect(() =>
+      validateXmlTemplate('<section name="{stringgggg}"><title>{string}</title></section>')
+    ).toThrow(/\{stringgggg\}/);
+  });
+
+  it("reports all invalid tokens at once, not just the first", () => {
+    try {
+      validateXmlTemplate('<book edition="{sdasasd}" pages="{numberz}"><title>{string}</title></book>');
+      expect.unreachable();
+    } catch (err: any) {
+      expect(err.message).toContain("{sdasasd}");
+      expect(err.message).toContain("{numberz}");
+    }
+  });
+
+  it("rejects empty braces", () => {
+    expect(() => validateXmlTemplate('<book id="{}"><title>{string}</title></book>')).toThrow(/\{\}/);
+  });
+});
+
+// ─── stripXmlProlog ───────────────────────────────────────────────────────────
+
+describe("stripXmlProlog", () => {
+  it("removes a leading XML declaration", () => {
+    const withProlog = '<?xml version="1.0" encoding="UTF-8"?>\n<book><title>Test</title></book>';
+    expect(stripXmlProlog(withProlog)).toBe("<book><title>Test</title></book>");
+  });
+
+  it("leaves content untouched when there is no prolog", () => {
+    const noProlog = "<book><title>Test</title></book>";
+    expect(stripXmlProlog(noProlog)).toBe(noProlog);
+  });
+
+  it("handles a UTF-8 BOM before the declaration", () => {
+    const withBom = '﻿<?xml version="1.0"?>\n<book/>';
+    expect(stripXmlProlog(withBom)).toBe("<book/>");
+  });
 });
 
 // ─── validateXmlOutput — required nodes ──────────────────────────────────────
@@ -89,9 +192,242 @@ describe("validateXmlOutput — required nodes", () => {
   });
 });
 
+// ─── reconcileLiterals ────────────────────────────────────────────────────────
+
+describe("reconcileLiterals", () => {
+  it("forces a root-level literal to the template's value, ignoring the model's output", async () => {
+    const { parseXmlTemplate, reconcileLiterals } = await import("../src/core/xml.js");
+    // exact bug scenario: unbraced literal the model "helpfully" replaced
+    const template = parseXmlTemplate(
+      '<xs:library updated="some-randome-date-after-2026"><xs:title>{string}</xs:title></xs:library>'
+    );
+    const modelOutput = parseXml('<xs:library updated="2024-05-01"><xs:title>The Road</xs:title></xs:library>');
+    const reconciled = reconcileLiterals(template, modelOutput) as any;
+    expect(reconciled["xs:library"]["@_updated"]).toBe("some-randome-date-after-2026");
+    expect(reconciled["xs:library"]["xs:title"]).toBe("The Road"); // placeholder value untouched
+  });
+
+  it("preserves an unbraced literal even when the model left it alone", async () => {
+    const { parseXmlTemplate, reconcileLiterals } = await import("../src/core/xml.js");
+    const template = parseXmlTemplate('<library totalBooks="90"><title>{string}</title></library>');
+    const modelOutput = parseXml('<library totalBooks="90"><title>The Road</title></library>');
+    const reconciled = reconcileLiterals(template, modelOutput) as any;
+    expect(reconciled.library["@_totalBooks"]).toBe("90");
+  });
+
+  it("applies the same literal to every item in a repeated array", async () => {
+    const { parseXmlTemplate, reconcileLiterals } = await import("../src/core/xml.js");
+    const template = parseXmlTemplate('<lib><book unit="each"><title>{string}</title></book></lib>');
+    const modelOutput = parseXml(
+      '<lib><book unit="wrong"><title>A</title></book><book unit="also-wrong"><title>B</title></book></lib>'
+    );
+    const reconciled = reconcileLiterals(template, modelOutput) as any;
+    expect(reconciled.lib.book[0]["@_unit"]).toBe("each");
+    expect(reconciled.lib.book[1]["@_unit"]).toBe("each");
+    expect(reconciled.lib.book[0].title).toBe("A"); // placeholders still per-item
+    expect(reconciled.lib.book[1].title).toBe("B");
+  });
+
+  it("forces a literal in even when the model omitted the whole node", async () => {
+    const { parseXmlTemplate, reconcileLiterals } = await import("../src/core/xml.js");
+    const template = parseXmlTemplate('<book><meta source="internal-catalog"/><title>{string}</title></book>');
+    const modelOutput = parseXml("<book><title>The Road</title></book>"); // model dropped <meta>
+    const reconciled = reconcileLiterals(template, modelOutput) as any;
+    expect(reconciled.book.meta["@_source"]).toBe("internal-catalog");
+  });
+
+  it("does not inject an empty tag for an omitted placeholder-only subtree", async () => {
+    const { parseXmlTemplate, reconcileLiterals } = await import("../src/core/xml.js");
+    const template = parseXmlTemplate("<book><optional><note>{string}</note></optional><title>{string}</title></book>");
+    const modelOutput = parseXml("<book><title>The Road</title></book>"); // model dropped <optional> entirely
+    const reconciled = reconcileLiterals(template, modelOutput) as any;
+    expect(reconciled.book.optional).toBeUndefined();
+  });
+
+  it("keeps extra keys the model added beyond the template", async () => {
+    const { parseXmlTemplate, reconcileLiterals } = await import("../src/core/xml.js");
+    const template = parseXmlTemplate("<book><title>{string}</title></book>");
+    const modelOutput = parseXml("<book><title>The Road</title><isbn>978-1</isbn></book>");
+    const reconciled = reconcileLiterals(template, modelOutput) as any;
+    expect(reconciled.book.isbn).toBe("978-1");
+  });
+});
+
 // ─── generate() with mock model ──────────────────────────────────────────────
 
 describe("generate() with XML schema — mock model", () => {
+  it("enforceLiterals: fixes an unbraced literal the model changed (root attribute)", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        // model "helpfully" replaced the literal date with one from context
+        return '<xs:library updated="2024-05-01"><xs:title>The Road</xs:title></xs:library>' as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: '<xs:library updated="some-randome-date-after-2026"><xs:title>{string}</xs:title></xs:library>',
+          enforceLiterals: true,
+        },
+      },
+      "Get book"
+    );
+
+    expect(result.data).toContain('updated="some-randome-date-after-2026"');
+    expect(result.data).toContain("<xs:title>The Road</xs:title>");
+  });
+
+  it("enforceLiterals: false (default) leaves the model's altered literal as-is", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return '<xs:library updated="2024-05-01"><xs:title>The Road</xs:title></xs:library>' as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: '<xs:library updated="some-randome-date-after-2026"><xs:title>{string}</xs:title></xs:library>',
+        },
+      },
+      "Get book"
+    );
+
+    // without enforceLiterals, whatever the model produced passes through unchanged
+    expect(result.data).toContain('updated="2024-05-01"');
+  });
+
+  it("enforceLiterals: parse: true returns the corrected object", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return '<book totalBooks="99"><title>The Road</title></book>' as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xml: { template: '<book totalBooks="90"><title>{string}</title></book>', enforceLiterals: true, parse: true } },
+      "Get book"
+    );
+
+    expect((result.data as any)["@_totalBooks"]).toBe("90");
+    expect((result.data as any).title).toBe("The Road");
+  });
+
+  it("enforceLiterals: forces literals across every repeated array item", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return "<lib><book unit=\"wrong\"><title>A</title></book><book unit=\"still-wrong\"><title>B</title></book></lib>" as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      {
+        xml: {
+          template: '<lib><book unit="each"><title>{string}</title></book></lib>',
+          enforceLiterals: true,
+          arrays: ["book"],
+        },
+      },
+      "Get catalog"
+    );
+
+    const occurrences = (result.data as string).match(/unit="each"/g) ?? [];
+    expect(occurrences).toHaveLength(2);
+  });
+
+  it("enforceLiterals with prolog: true adds a standard XML declaration", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return "<book><title>Test</title></book>" as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xml: { template: "<book><title>{string}</title></book>", enforceLiterals: true, prolog: true } },
+      "Get book"
+    );
+
+    expect(result.data).toMatch(/^<\?xml/);
+  });
+  it("throws synchronously before any model call for an invalid template", async () => {
+    const { buildStructuredPrompt } = await import("../src/core/schema.js");
+    const generateSpy = vi.fn();
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(prompt: string, schema: any, systemPrompt?: string): Promise<T> {
+        // mimic a real backend: build the prompt before making any "API call"
+        buildStructuredPrompt(prompt, schema, systemPrompt);
+        generateSpy();
+        return "<book><title>X</title></book>" as T;
+      },
+    };
+
+    await expect(
+      generate(
+        model,
+        { xml: { template: '<book edition="{sdasasd}"><title>{string}</title></book>' } },
+        "Get book"
+      )
+    ).rejects.toThrow(/Invalid placeholder/);
+
+    // fails fast — no retries, no wasted model calls
+    expect(generateSpy).not.toHaveBeenCalled();
+  });
+
+  it("default strips a model-added XML prolog", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return '<?xml version="1.0" encoding="UTF-8"?>\n<book><title>Clean Code</title></book>' as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xml: { template: "<book><title>{string}</title></book>" } },
+      "Get book"
+    );
+
+    expect(result.data).not.toContain("<?xml");
+    expect(result.data).toBe("<book><title>Clean Code</title></book>");
+  });
+
+  it("prolog: true keeps a model-added XML prolog", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return '<?xml version="1.0" encoding="UTF-8"?>\n<book><title>Clean Code</title></book>' as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xml: { template: "<book><title>{string}</title></book>", prolog: true } },
+      "Get book"
+    );
+
+    expect(result.data).toContain("<?xml");
+  });
+
   it("default returns the validated XML string", async () => {
     const model: ShapecraftModel = {
       id: "mock",

--- a/tests/xml.test.ts
+++ b/tests/xml.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect } from "vitest";
+import { generate } from "../src/core/generate.js";
+import { xmlObjectToTemplate, parseXml, validateXmlOutput, buildXmlSystemPrompt } from "../src/core/xml.js";
+import { anthropic } from "../src/backends/anthropic.js";
+import { groq } from "../src/backends/groq.js";
+import { MaxRetriesExceededError, SchemaViolationError } from "../src/types.js";
+import type { XmlObjectInput, XmlTemplateInput, ShapecraftModel } from "../src/types.js";
+
+const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
+const hasGroq = !!process.env.GROQ_API_KEY;
+
+// ─── xmlObjectToTemplate ─────────────────────────────────────────────────────
+
+describe("xmlObjectToTemplate", () => {
+  it("flat fields", () => {
+    const input: XmlObjectInput = {
+      xmlObject: { root: "book", fields: { title: "string", author: "string" } },
+    };
+    const tmpl = xmlObjectToTemplate(input);
+    expect(tmpl).toContain("<book>");
+    expect(tmpl).toContain("<title>{string}</title>");
+    expect(tmpl).toContain("<author>{string}</author>");
+    expect(tmpl).toContain("</book>");
+  });
+
+  it("nested object field", () => {
+    const input: XmlObjectInput = {
+      xmlObject: {
+        root: "order",
+        fields: {
+          id: "string",
+          address: { type: "object", fields: { city: "string", zip: "string" } },
+        },
+      },
+    };
+    const tmpl = xmlObjectToTemplate(input);
+    expect(tmpl).toContain("<address>");
+    expect(tmpl).toContain("<city>{string}</city>");
+  });
+
+  it("array field", () => {
+    const input: XmlObjectInput = {
+      xmlObject: {
+        root: "library",
+        fields: {
+          books: { type: "array", items: { title: "string", year: "number" } },
+        },
+      },
+    };
+    const tmpl = xmlObjectToTemplate(input);
+    expect(tmpl).toContain("<books>");
+    expect(tmpl).toContain("<item>");
+    expect(tmpl).toContain("<year>{number}</year>");
+  });
+});
+
+// ─── parseXml ────────────────────────────────────────────────────────────────
+
+describe("parseXml", () => {
+  it("parses flat XML", () => {
+    const raw = "<book><title>XML in Practice</title><author>Jane Smith</author></book>";
+    const result = parseXml(raw);
+    expect(result).toMatchObject({ book: { title: "XML in Practice", author: "Jane Smith" } });
+  });
+
+  it("parses nested XML", () => {
+    const raw = "<order><id>42</id><address><city>NYC</city><zip>10001</zip></address></order>";
+    const result = parseXml(raw);
+    expect((result as any).order.address.city).toBe("NYC");
+  });
+
+  it("strips markdown code fences", () => {
+    const raw = "```xml\n<book><title>Test</title></book>\n```";
+    const result = parseXml(raw);
+    expect((result as any).book.title).toBe("Test");
+  });
+
+  it("normalizes array paths", () => {
+    const raw = "<library><book><title>A</title></book></library>";
+    const result = parseXml(raw, ["book"]);
+    expect(Array.isArray((result as any).library.book)).toBe(true);
+  });
+
+  it("lenient parser handles unclosed tags as empty node", () => {
+    const result = parseXml("<unclosed>");
+    expect(result).toMatchObject({ unclosed: "" });
+  });
+});
+
+// ─── validateXmlOutput ───────────────────────────────────────────────────────
+
+describe("validateXmlOutput", () => {
+  it("extracts root and coerces types", () => {
+    const parsed = { book: { title: "Test", pages: "320" } };
+    const schema: XmlObjectInput = {
+      xmlObject: { root: "book", fields: { title: "string", pages: "number" } },
+    };
+    const result = validateXmlOutput(parsed, schema) as any;
+    expect(result.title).toBe("Test");
+    expect(result.pages).toBe(320);
+  });
+
+  it("throws on missing required field", () => {
+    const parsed = { book: { title: "Test" } };
+    const schema: XmlObjectInput = {
+      xmlObject: { root: "book", fields: { title: "string", author: "string" } },
+    };
+    expect(() => validateXmlOutput(parsed, schema)).toThrow(SchemaViolationError);
+  });
+
+  it("throws on missing root element", () => {
+    const parsed = { person: { name: "John" } };
+    const schema: XmlObjectInput = {
+      xmlObject: { root: "book", fields: { title: "string" } },
+    };
+    expect(() => validateXmlOutput(parsed, schema)).toThrow();
+  });
+
+  it("xmlTemplate returns root element", () => {
+    const parsed = { book: { title: "Test", author: "Jane" } };
+    const schema: XmlTemplateInput = { xmlTemplate: "<book><title>{string}</title></book>" };
+    const result = validateXmlOutput(parsed, schema) as any;
+    expect(result.title).toBe("Test");
+  });
+});
+
+// ─── buildXmlSystemPrompt ────────────────────────────────────────────────────
+
+describe("buildXmlSystemPrompt", () => {
+  it("includes template structure for xmlObject", () => {
+    const schema: XmlObjectInput = {
+      xmlObject: { root: "book", fields: { title: "string" } },
+    };
+    const prompt = buildXmlSystemPrompt(schema);
+    expect(prompt).toContain("<book>");
+    expect(prompt).toContain("{string}");
+  });
+
+  it("uses template string directly for xmlTemplate", () => {
+    const schema: XmlTemplateInput = { xmlTemplate: "<person><name>{string}</name></person>" };
+    const prompt = buildXmlSystemPrompt(schema);
+    expect(prompt).toContain("<person>");
+  });
+});
+
+// ─── generate() with mock model ──────────────────────────────────────────────
+
+describe("generate() with XML schema — mock model", () => {
+  it("xmlObject: parses and validates LLM XML output", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return "<book><title>XML in Practice</title><author>Jane Smith</author><pages>320</pages></book>" as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      {
+        xmlObject: {
+          root: "book",
+          fields: { title: "string", author: "string", pages: "number" },
+        },
+      },
+      "Extract book info"
+    );
+
+    expect(result.data).toMatchObject({ title: "XML in Practice", author: "Jane Smith", pages: 320 });
+    expect(result.attempts).toBe(1);
+  });
+
+  it("xmlTemplate: parses LLM XML output and returns root element", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return "<person><name>Alice</name><age>30</age></person>" as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xmlTemplate: "<person><name>{string}</name><age>{number}</age></person>" },
+      "Extract person info"
+    );
+
+    expect((result.data as any).name).toBe("Alice");
+  });
+
+  it("retries on invalid XML output", async () => {
+    let calls = 0;
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        calls++;
+        if (calls < 2) return "not xml at all" as T;
+        return "<book><title>Valid</title><author>Author</author></book>" as T;
+      },
+    };
+
+    const result = await generate(
+      model,
+      { xmlObject: { root: "book", fields: { title: "string", author: "string" } } },
+      "Get book"
+    );
+
+    expect(result.attempts).toBe(2);
+    expect((result.data as any).title).toBe("Valid");
+  });
+
+  it("exhausts retries on consistently bad output", async () => {
+    const model: ShapecraftModel = {
+      id: "mock",
+      guaranteeLevel: "best-effort",
+      async generate<T>(): Promise<T> {
+        return "<person><name>Alice</name></person>" as T;
+      },
+    };
+
+    await expect(
+      generate(
+        model,
+        { xmlObject: { root: "book", fields: { title: "string", author: "string" } } },
+        "Get book",
+        { maxRetries: 2 }
+      )
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+});
+
+// ─── Real API tests ───────────────────────────────────────────────────────────
+
+describe("XML — Anthropic backend (real API)", () => {
+  it.skipIf(!hasAnthropic)("xmlObject: flat book extraction", async () => {
+    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+    const result = await generate(
+      model,
+      { xmlObject: { root: "book", fields: { title: "string", author: "string", year: "number" } } },
+      'Extract book info: "XML in Practice" by Jane Smith, published in 2003.'
+    );
+    expect((result.data as any).title).toContain("XML");
+    expect((result.data as any).year).toBe(2003);
+    console.log("[anthropic] xmlObject result:", result.data);
+  }, 30_000);
+
+  it.skipIf(!hasAnthropic)("xmlTemplate: person extraction", async () => {
+    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+    const result = await generate(
+      model,
+      {
+        xmlTemplate: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n  <city>{string}</city>\n</person>`,
+      },
+      "Extract: John Doe, 35 years old, lives in San Francisco."
+    );
+    expect((result.data as any).name).toContain("John");
+    expect((result.data as any).age).toBe(35);
+    console.log("[anthropic] xmlTemplate result:", result.data);
+  }, 30_000);
+
+  it.skipIf(!hasAnthropic)("xmlObject: nested address", async () => {
+    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+    const result = await generate(
+      model,
+      {
+        xmlObject: {
+          root: "order",
+          fields: {
+            id: "string",
+            address: { type: "object", fields: { city: "string", country: "string" } },
+          },
+        },
+      },
+      'Order #ORD-001, shipping to London, United Kingdom.'
+    );
+    expect((result.data as any).address.city).toBeTruthy();
+    console.log("[anthropic] nested result:", result.data);
+  }, 30_000);
+});
+
+describe("XML — Groq backend (real API)", () => {
+  it.skipIf(!hasGroq)("xmlObject: flat extraction", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      { xmlObject: { root: "book", fields: { title: "string", author: "string" } } },
+      'Extract book: "Clean Code" by Robert C. Martin.'
+    );
+    expect((result.data as any).title).toBeTruthy();
+    console.log("[groq] xmlObject result:", result.data);
+  }, 30_000);
+
+  it.skipIf(!hasGroq)("xmlTemplate: person extraction", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      {
+        xmlTemplate: `<person>\n  <name>{string}</name>\n  <age>{number}</age>\n</person>`,
+      },
+      "Extract: Sarah Connor, 29 years old."
+    );
+    expect((result.data as any).name).toBeTruthy();
+    console.log("[groq] xmlTemplate result:", result.data);
+  }, 30_000);
+});


### PR DESCRIPTION
- Adds XML output support to generate() — model returns XML, library parses it into a typed JS object.
- Two input styles: xmlObject (root + typed fields, nested/array/leaf) and xmlTemplate (example shape with {placeholder}s).
- Runs through the same generate() flow: parses with fast-xml-parser, unwraps <item> arrays, coerces leaf types.
- Verified across Anthropic, Ollama, and Groq; full test coverage in tests/xml.test.ts.

Two ways to declare an XML shape:

- **`xmlObject`** — declare a root tag and typed fields; supports nested objects, arrays, and `string`/`number`/`boolean` leaves:
  ```ts
  generate(model, {
    xmlObject: { root: 'book', fields: { title: 'string', author: 'string', year: 'number' } }
  }, prompt)
  // → { title: 'XML in Practice', author: 'Jane Smith', year: 2003 }