### PR TITLE
feat: add conversational multi-turn schema collection (turnaround mode)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,6 @@ dist/
 .env
 .env.local
 *.log
-PLAN.md
+*.md
+!README.md
+!CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -242,6 +242,19 @@ const local  = ollama({ model: "llama3.2" });
 const claude = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
 ```
 
+## What shapecraft guarantees — and what it doesn't
+
+Every mechanism above (`native`, `constrained`, `best-effort` + retry) targets one thing: **the output is structurally valid** — it parses, the types match, required fields are present and non-empty. That's a real, load-bearing guarantee: it's the difference between code that can trust `result.data.age` is a `number` versus code that has to defensively re-check everything the model says.
+
+What it doesn't cover is **whether a value is actually true.** A schema (or GBNF grammar) constrains *shape*, not *content* — a model can be perfectly schema-compliant while filling a field from its own priors instead of your source text. For example: a required `date` field that always parses, always matches the type, and is occasionally fabricated because the source text simply didn't contain a date. Nothing in `required`, type-checking, or `enforceLiterals` catches that — none of it throws, because nothing about the output is structurally wrong.
+
+So think of it as two layers:
+
+- **Structural correctness** (shapecraft's job): valid JSON/XML, correct types, required fields present. Solved.
+- **Semantic correctness** ("is this value actually grounded in the input?"): a separate concern shapecraft doesn't attempt today. If your use case needs that guarantee — financial data, dates, anything where a plausible-but-wrong value is costly — pair shapecraft with your own grounding check (e.g. verifying extracted values trace back to the source text) or a second-pass verifier, rather than trusting `required` alone.
+
+This isn't a reason to avoid structural validation — it eliminates an entire class of bugs (parse errors, wrong types, missing fields) that would otherwise hit you in production. It just isn't the same guarantee as "this value is correct," and knowing the boundary is what lets you build the right check on top for the cases that need one.
+
 ## Options
 
 ```typescript

--- a/examples/turnaround.ts
+++ b/examples/turnaround.ts
@@ -1,0 +1,66 @@
+/**
+ * Example: Turnaround — conversational, multi-turn schema collection.
+ *
+ * Instead of one prompt -> one structured object, the model interviews the
+ * user across turns (per your systemPrompt) and shapecraft just relays its
+ * replies. Nothing is validated until the model signals it's done — then
+ * shapecraft extracts + validates once, over the whole transcript.
+ *
+ * `memory` is a plain, JSON-serializable object — thread the previous
+ * result's `memory` back in on each call. In a real app each turn is a
+ * separate HTTP request; persist `memory` between them (see the stateless
+ * server pattern in README.md).
+ */
+import { generate, anthropic } from "@aviasole/shapecraft";
+
+const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+
+const schema = {
+  jsonSchema: {
+    type: "object",
+    required: ["problem", "idea", "user"],
+    properties: {
+      problem: { type: "string" },
+      idea: { type: "string" },
+      user: { type: "string" },
+    },
+  },
+};
+
+const FACILITATOR =
+  "You are the Discover Facilitator. Ask exactly one focused question at a time to extract: " +
+  "(1) What problem are we solving? (2) What is the idea? (3) Who is the user? " +
+  "Probe vague answers for specifics. Do not invent details on the user's behalf.";
+
+let r = await generate(model, schema, "Hii", { systemPrompt: FACILITATOR }, { turnaround: true });
+console.log(r.status === "collecting" ? r.message : r); // "What problem are you trying to solve?"
+
+r = await generate(
+  model,
+  schema,
+  "Onboarding new hires takes 3 weeks because of manual account setup",
+  { systemPrompt: FACILITATOR },
+  { turnaround: true, memory: r.memory }
+);
+console.log(r.status === "collecting" ? r.message : r); // "What's your idea for solving this?"
+
+r = await generate(
+  model,
+  schema,
+  "A dashboard that auto-provisions accounts and routes approvals",
+  { systemPrompt: FACILITATOR },
+  { turnaround: true, memory: r.memory }
+);
+console.log(r.status === "collecting" ? r.message : r); // "Who is the user for this dashboard?"
+
+r = await generate(
+  model,
+  schema,
+  "HR onboarding coordinators",
+  { systemPrompt: FACILITATOR },
+  { turnaround: true, memory: r.memory }
+);
+
+if (r.status === "complete") {
+  console.log(r.data); // { problem: "...", idea: "...", user: "..." } — extracted & validated once, here
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -1,4 +1,4 @@
-import type { SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
 
@@ -10,24 +10,25 @@ export interface AnthropicBackendOptions {
 export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftModel {
   const modelId = options.model ?? "claude-sonnet-4-6";
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("@anthropic-ai/sdk").catch(() => {
+      throw new Error("Install sdk: npm install @anthropic-ai/sdk");
+    });
+    const AnthropicClass = mod.default ?? mod;
+    return new AnthropicClass({ apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY });
+  }
+
   return {
     id: `anthropic:${modelId}`,
     guaranteeLevel: "best-effort",
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mod: any = await import("@anthropic-ai/sdk").catch(() => {
-        throw new Error("Install sdk: npm install @anthropic-ai/sdk");
-      });
-
-      const AnthropicClass = mod.default ?? mod;
-      const client = new AnthropicClass({
-        apiKey: options.apiKey ?? process.env.ANTHROPIC_API_KEY,
-      });
-
+      const anthropicClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const response = await client.messages.create({
+      const response = await anthropicClient.messages.create({
         model: modelId,
         max_tokens: 4096,
         system,
@@ -38,6 +39,19 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
         response.content[0]?.type === "text" ? response.content[0].text : "";
 
       return parseAndValidate<T>(raw, schema, { extractJson: true });
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const anthropicClient = await client();
+
+      const response = await anthropicClient.messages.create({
+        model: modelId,
+        max_tokens: 1024,
+        system: systemPrompt,
+        messages: messages.map((m) => ({ role: m.role, content: m.content })),
+      });
+
+      return response.content[0]?.type === "text" ? response.content[0].text : "";
     },
   };
 }

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -1,4 +1,4 @@
-import type { SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
 import { isXmlInput } from "../core/validate.js";
@@ -11,24 +11,25 @@ export interface GroqBackendOptions {
 export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
   const modelId = options.model ?? "llama-3.3-70b-versatile";
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("groq-sdk").catch(() => {
+      throw new Error("Install groq: npm install groq-sdk");
+    });
+    const Groq = mod.default ?? mod;
+    return new Groq({ apiKey: options.apiKey ?? process.env.GROQ_API_KEY });
+  }
+
   return {
     id: `groq:${modelId}`,
     guaranteeLevel: "native",
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mod: any = await import("groq-sdk").catch(() => {
-        throw new Error("Install groq: npm install groq-sdk");
-      });
-
-      const Groq = mod.default ?? mod;
-      const client = new Groq({
-        apiKey: options.apiKey ?? process.env.GROQ_API_KEY,
-      });
-
+      const groqClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const response = await client.chat.completions.create({
+      const response = await groqClient.chat.completions.create({
         model: modelId,
         messages: [
           { role: "system", content: system },
@@ -41,6 +42,20 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
       const raw: string = response.choices[0]?.message?.content ?? "";
 
       return parseAndValidate<T>(raw, schema);
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const groqClient = await client();
+
+      const response = await groqClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+          ...messages.map((m) => ({ role: m.role, content: m.content })),
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
     },
   };
 }

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
@@ -52,6 +52,29 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
       const raw = json.message?.content ?? "";
 
       return parseAndValidate<T>(raw, schema);
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const response = await fetch(`${host}/api/chat`, {
+        signal: AbortSignal.timeout(timeoutMs),
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: options.model,
+          messages: [
+            ...(systemPrompt ? [{ role: "system", content: systemPrompt }] : []),
+            ...messages.map((m) => ({ role: m.role, content: m.content })),
+          ],
+          stream: false,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama error: ${response.status} ${response.statusText}`);
+      }
+
+      const json = (await response.json()) as { message?: { content?: string } };
+      return json.message?.content ?? "";
     },
   };
 }

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
@@ -13,22 +13,22 @@ export interface OpenAIBackendOptions {
 export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
   const modelId = options.model ?? "gpt-4o-mini";
 
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("openai").catch(() => {
+      throw new Error("Install openai: npm install openai");
+    });
+    const OpenAI = mod.default ?? mod;
+    return new OpenAI({ apiKey: options.apiKey ?? process.env.OPENAI_API_KEY, baseURL: options.baseURL });
+  }
+
   return {
     id: `openai:${modelId}`,
     guaranteeLevel: "native",
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const mod: any = await import("openai").catch(() => {
-        throw new Error("Install openai: npm install openai");
-      });
-
-      const OpenAI = mod.default ?? mod;
-      const client = new OpenAI({
-        apiKey: options.apiKey ?? process.env.OPENAI_API_KEY,
-        baseURL: options.baseURL,
-      });
-
+      const openaiClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
       // Use strict json_schema mode for Zod, non-strict for raw jsonSchema, json_object otherwise
@@ -44,7 +44,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
             }
           : { type: "json_object" as const };
 
-      const response = await client.chat.completions.create({
+      const response = await openaiClient.chat.completions.create({
         model: modelId,
         messages: [
           { role: "system", content: system },
@@ -56,6 +56,20 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
       const raw: string = response.choices[0]?.message?.content ?? "";
 
       return parseAndValidate<T>(raw, schema);
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const openaiClient = await client();
+
+      const response = await openaiClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+          ...messages.map((m) => ({ role: m.role, content: m.content })),
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
     },
   };
 }

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -1,13 +1,39 @@
-import type { GenerateOptions, GenerateResult, SchemaInput, ShapecraftModel } from "../types.js";
+import type {
+  GenerateOptions,
+  GenerateResult,
+  SchemaInput,
+  ShapecraftModel,
+  TurnaroundOptions,
+  TurnResult,
+} from "../types.js";
 import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
 import { validateOutput } from "./validate.js";
+import { runTurnaround } from "./turnaround.js";
 
+export function generate<T>(
+  model: ShapecraftModel,
+  schema: SchemaInput<T>,
+  prompt: string,
+  options?: GenerateOptions
+): Promise<GenerateResult<T>>;
+export function generate<T>(
+  model: ShapecraftModel,
+  schema: SchemaInput<T>,
+  prompt: string,
+  options: GenerateOptions,
+  turnaround: TurnaroundOptions
+): Promise<TurnResult<T>>;
 export async function generate<T>(
   model: ShapecraftModel,
   schema: SchemaInput<T>,
   prompt: string,
-  options: GenerateOptions = {}
-): Promise<GenerateResult<T>> {
+  options: GenerateOptions = {},
+  turnaround?: TurnaroundOptions
+): Promise<GenerateResult<T> | TurnResult<T>> {
+  if (turnaround?.turnaround) {
+    return runTurnaround<T>(model, schema, prompt, options, turnaround);
+  }
+
   const maxRetries = options.maxRetries ?? 3;
   const { systemPrompt } = options;
 

--- a/src/core/turnaround.ts
+++ b/src/core/turnaround.ts
@@ -1,0 +1,122 @@
+import { z } from "zod";
+import type {
+  ChatMessage,
+  ConversationMemory,
+  GenerateOptions,
+  SchemaInput,
+  ShapecraftModel,
+  TurnaroundOptions,
+  TurnResult,
+} from "../types.js";
+import { MaxTurnsExceededError } from "../types.js";
+import { generate } from "./generate.js";
+import { isXmlInput } from "./validate.js";
+
+/** Emitted alone by the model to signal the conversation has everything it needs. */
+export const COMPLETION_SENTINEL = "<<<COMPLETE>>>";
+
+export function createConversationMemory(): ConversationMemory {
+  return { messages: [], status: "collecting", turns: 0 };
+}
+
+/**
+ * Best-effort list of the schema's required field names, so the model can be
+ * given an explicit checklist instead of inferring "done" purely from prose in
+ * the caller's systemPrompt. Returns undefined for schema types with no named
+ * fields (pattern, custom validator without a hint) — the checklist is skipped.
+ */
+function requiredFieldNames<T>(schema: SchemaInput<T>): string[] | undefined {
+  if (schema instanceof z.ZodType) {
+    // Read the shape directly rather than going through toJsonSchema — reliable
+    // across zod versions and doesn't depend on zod-to-json-schema's internals.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shape = (schema as any).shape as Record<string, z.ZodTypeAny> | undefined;
+    if (!shape) return undefined;
+    return Object.entries(shape)
+      .filter(([, field]) => !field.isOptional())
+      .map(([key]) => key);
+  }
+  if (isXmlInput(schema)) {
+    return schema.xml.required;
+  }
+  if ("jsonSchema" in (schema as object)) {
+    const required = (schema as { jsonSchema: Record<string, unknown> }).jsonSchema.required;
+    return Array.isArray(required) ? (required as string[]) : undefined;
+  }
+  return undefined;
+}
+
+function buildTurnaroundSystemPrompt<T>(schema: SchemaInput<T>, systemPrompt?: string): string {
+  const required = requiredFieldNames(schema);
+
+  const checklistInstruction = required?.length
+    ? `You need clear, specific answers covering exactly these items: ${required.join(", ")}. ` +
+      `Ask at most one focused follow-up per item to get a specific answer — do not keep probing an ` +
+      `item once it has a clear, specific answer. `
+    : "";
+
+  const sentinelInstruction =
+    `${checklistInstruction}When — and only when — every item has a clear, specific answer, ` +
+    `reply with exactly "${COMPLETION_SENTINEL}" and nothing else — no other words, no punctuation. ` +
+    `Until then, reply with exactly one focused question, probe, or acknowledgment per turn. ` +
+    `Never include "${COMPLETION_SENTINEL}" in a reply that also contains a question or any other text.`;
+
+  return systemPrompt ? `${systemPrompt}\n\n${sentinelInstruction}` : sentinelInstruction;
+}
+
+function transcriptToText(messages: ChatMessage[]): string {
+  return messages.map((m) => `${m.role === "user" ? "User" : "Assistant"}: ${m.content}`).join("\n");
+}
+
+export async function runTurnaround<T>(
+  model: ShapecraftModel,
+  schema: SchemaInput<T>,
+  userMessage: string,
+  options: GenerateOptions,
+  turnaroundOptions: TurnaroundOptions
+): Promise<TurnResult<T>> {
+  if (!model.chat) {
+    throw new Error(`Model "${model.id}" does not support turnaround mode (missing chat()).`);
+  }
+
+  const memory = turnaroundOptions.memory ?? createConversationMemory();
+  if (memory.status === "complete") {
+    throw new Error("This conversation has already completed — start a new one.");
+  }
+
+  const maxTurns = turnaroundOptions.maxTurns ?? 20;
+  memory.turns += 1;
+  if (memory.turns > maxTurns) {
+    throw new MaxTurnsExceededError(maxTurns);
+  }
+
+  memory.messages.push({ role: "user", content: userMessage });
+
+  const turnSystemPrompt = buildTurnaroundSystemPrompt(schema, options.systemPrompt);
+  const reply = await model.chat(memory.messages, turnSystemPrompt);
+  const trimmed = reply.trim();
+
+  if (trimmed === COMPLETION_SENTINEL) {
+    memory.messages.push({ role: "assistant", content: reply });
+
+    // Single structured pass over the whole transcript — a normal, non-turnaround
+    // generate() call. This is the ONE validation for the entire conversation.
+    const transcript = transcriptToText(memory.messages);
+    const extracted = await generate<T>(
+      model,
+      schema,
+      `Extract the structured data collected in the following conversation:\n\n${transcript}`,
+      options.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}
+    );
+
+    memory.status = "complete";
+    return { status: "complete", data: extracted.data, memory };
+  }
+
+  // Defensive guard (§9): the sentinel should only ever appear alone. If the model
+  // leaks it alongside other content, strip it and keep collecting — never forward it.
+  const cleaned = trimmed.includes(COMPLETION_SENTINEL) ? trimmed.replace(COMPLETION_SENTINEL, "").trim() : reply;
+
+  memory.messages.push({ role: "assistant", content: cleaned });
+  return { status: "collecting", message: cleaned, memory };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 export { generate } from "./core/generate.js";
 export { toJsonSchema, buildStructuredPrompt } from "./core/schema.js";
 export { xmlType, validateXmlTemplate } from "./core/xml.js";
+export { createConversationMemory, COMPLETION_SENTINEL } from "./core/turnaround.js";
 
 export * from "./backends/index.js";
 
@@ -11,6 +12,10 @@ export type {
   GenerateResult,
   GuaranteeLevel,
   XmlInput,
+  ChatMessage,
+  ConversationMemory,
+  TurnaroundOptions,
+  TurnResult,
 } from "./types.js";
 
-export { SchemaViolationError, MaxRetriesExceededError } from "./types.js";
+export { SchemaViolationError, MaxRetriesExceededError, MaxTurnsExceededError } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,10 +31,20 @@ export type XmlInput = {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput | XmlInput;
 
+export interface ChatMessage {
+  role: "user" | "assistant";
+  content: string;
+}
+
 export interface ShapecraftModel {
   id: string;
   guaranteeLevel: GuaranteeLevel;
   generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T>;
+  /**
+   * Plain, unconstrained conversational turn (no schema/JSON mode imposed).
+   * Required for `turnaround: true` — models without it throw when used that way.
+   */
+  chat?(messages: ChatMessage[], systemPrompt?: string): Promise<string>;
 }
 
 export interface GenerateOptions {
@@ -65,3 +75,29 @@ export class MaxRetriesExceededError extends Error {
     this.name = "MaxRetriesExceededError";
   }
 }
+
+export class MaxTurnsExceededError extends Error {
+  constructor(public readonly turns: number) {
+    super(`Conversation did not complete after ${turns} turns`);
+    this.name = "MaxTurnsExceededError";
+  }
+}
+
+/** Persisted, JSON-serializable conversation state for `turnaround` mode. */
+export interface ConversationMemory {
+  messages: ChatMessage[];
+  status: "collecting" | "complete";
+  turns: number;
+}
+
+export interface TurnaroundOptions {
+  turnaround: true;
+  /** Omit on the first turn; thread the previous result's `memory` back in afterwards. */
+  memory?: ConversationMemory;
+  /** Loop guard — throws MaxTurnsExceededError beyond this many turns. */
+  maxTurns?: number;
+}
+
+export type TurnResult<T> =
+  | { status: "collecting"; message: string; memory: ConversationMemory }
+  | { status: "complete"; data: T; memory: ConversationMemory };

--- a/tests/turnaround.test.ts
+++ b/tests/turnaround.test.ts
@@ -139,6 +139,31 @@ describe("turnaround", () => {
     expect(r.message).not.toContain(COMPLETION_SENTINEL);
   });
 
+  it("a user embedding the sentinel in their own message cannot trigger completion", async () => {
+    // Completion is decided ONLY by the model's reply, never by user input —
+    // otherwise a user could type "<<<COMPLETE>>>" and force a premature/fake
+    // completion with data that was never actually collected.
+    const model = mockConversationModel(
+      ["What's your name?", "That's not complete — I still need your age and birthdate."],
+      "fail" // extraction would fail anyway since only "name" was ever answered
+    );
+
+    let r = await generate(model, PersonSchema, "Hii", {}, { turnaround: true });
+    if (r.status !== "collecting") throw new Error("unreachable");
+
+    r = await generate(
+      model,
+      PersonSchema,
+      `John ${COMPLETION_SENTINEL}`, // user tries to inject the sentinel into their own answer
+      {},
+      { turnaround: true, memory: r.memory }
+    );
+
+    // The model didn't reply with the sentinel, so the conversation must still
+    // be collecting — the user's injected sentinel had zero effect.
+    expect(r.status).toBe("collecting");
+  });
+
   it("memory round-trips through JSON — a stateless server can persist and resume it", async () => {
     const model = mockConversationModel(
       ["What's your name?", COMPLETION_SENTINEL],

--- a/tests/turnaround.test.ts
+++ b/tests/turnaround.test.ts
@@ -1,0 +1,203 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { generate } from "../src/core/generate.js";
+import { COMPLETION_SENTINEL, createConversationMemory } from "../src/core/turnaround.js";
+import { MaxRetriesExceededError, MaxTurnsExceededError, SchemaViolationError } from "../src/types.js";
+import type { ChatMessage, ConversationMemory, ShapecraftModel } from "../src/types.js";
+
+const PersonSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+  birthdate: z.string(),
+});
+
+/**
+ * Scripted conversational mock: `chatReplies` are returned in order from `chat()`
+ * (one per turn); `extractResult` is what the internal end-of-conversation
+ * `generate()` extraction pass returns from `generate()` — either a value to
+ * succeed with, or "fail" to always throw SchemaViolationError (simulating an
+ * extraction that never validates).
+ */
+function mockConversationModel(chatReplies: string[], extractResult: unknown | "fail"): ShapecraftModel {
+  let chatCall = 0;
+  return {
+    id: "mock:turnaround",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      if (extractResult === "fail") throw new SchemaViolationError("bad extraction", "invalid");
+      return extractResult as T;
+    },
+    async chat(_messages: ChatMessage[], _systemPrompt?: string): Promise<string> {
+      const reply = chatReplies[chatCall];
+      chatCall++;
+      if (reply === undefined) throw new Error("mock exhausted: no scripted reply for this turn");
+      return reply;
+    },
+  };
+}
+
+describe("turnaround", () => {
+  it("forwards each question verbatim, then extracts + validates once at the sentinel", async () => {
+    const model = mockConversationModel(
+      ["What's your name?", "How old are you?", "And your birthdate?", COMPLETION_SENTINEL],
+      { name: "John", age: 32, birthdate: "1992-01-15" }
+    );
+
+    let r = await generate(model, PersonSchema, "Hii", { systemPrompt: "facilitator" }, { turnaround: true });
+    expect(r.status).toBe("collecting");
+    if (r.status !== "collecting") throw new Error("unreachable");
+    expect(r.message).toBe("What's your name?");
+
+    r = await generate(model, PersonSchema, "John", { systemPrompt: "facilitator" }, { turnaround: true, memory: r.memory });
+    expect(r.status).toBe("collecting");
+    if (r.status !== "collecting") throw new Error("unreachable");
+    expect(r.message).toBe("How old are you?");
+
+    r = await generate(model, PersonSchema, "32", { systemPrompt: "facilitator" }, { turnaround: true, memory: r.memory });
+    expect(r.status).toBe("collecting");
+    if (r.status !== "collecting") throw new Error("unreachable");
+    expect(r.message).toBe("And your birthdate?");
+
+    r = await generate(model, PersonSchema, "1992-01-15", { systemPrompt: "facilitator" }, { turnaround: true, memory: r.memory });
+    expect(r.status).toBe("complete");
+    if (r.status !== "complete") throw new Error("unreachable");
+    expect(r.data).toEqual({ name: "John", age: 32, birthdate: "1992-01-15" });
+    expect(r.memory.status).toBe("complete");
+  });
+
+  it("never forwards the extraction failure as a message — it throws instead", async () => {
+    const model = mockConversationModel(["What's your name?", COMPLETION_SENTINEL], "fail");
+
+    let r = await generate(model, PersonSchema, "Hii", {}, { turnaround: true });
+    if (r.status !== "collecting") throw new Error("unreachable");
+
+    await expect(
+      generate(model, PersonSchema, "John", {}, { turnaround: true, memory: r.memory })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("premature sentinel: incomplete data throws a terminal error, user is not re-interrogated", async () => {
+    // Sentinel arrives on turn 1 — no real answers were ever collected.
+    const model = mockConversationModel([COMPLETION_SENTINEL], "fail");
+
+    await expect(
+      generate(model, PersonSchema, "Hii", {}, { turnaround: true })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("real transport error is thrown, not swallowed into a message", async () => {
+    const model: ShapecraftModel = {
+      id: "mock:transport-fail",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        throw new Error("should not be called");
+      },
+      async chat(): Promise<string> {
+        throw new Error("network failure");
+      },
+    };
+
+    await expect(generate(model, PersonSchema, "Hii", {}, { turnaround: true })).rejects.toThrow("network failure");
+  });
+
+  it("model without chat() throws a clear error instead of silently failing", async () => {
+    const model: ShapecraftModel = {
+      id: "mock:no-chat",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        return {} as T;
+      },
+      // no chat()
+    };
+
+    await expect(generate(model, PersonSchema, "Hii", {}, { turnaround: true })).rejects.toThrow(/does not support turnaround/);
+  });
+
+  it("maxTurns guard terminates a never-completing conversation", async () => {
+    const model = mockConversationModel(["q1", "q2", "q3"], { name: "x", age: 1, birthdate: "x" });
+
+    let r = await generate(model, PersonSchema, "Hii", {}, { turnaround: true, maxTurns: 2 });
+    if (r.status !== "collecting") throw new Error("unreachable");
+
+    r = await generate(model, PersonSchema, "answer", {}, { turnaround: true, maxTurns: 2, memory: r.memory });
+    if (r.status !== "collecting") throw new Error("unreachable");
+
+    await expect(
+      generate(model, PersonSchema, "answer", {}, { turnaround: true, maxTurns: 2, memory: r.memory })
+    ).rejects.toBeInstanceOf(MaxTurnsExceededError);
+  });
+
+  it("strips a leaked sentinel mixed with other text and keeps collecting", async () => {
+    const model = mockConversationModel(
+      [`Almost done. ${COMPLETION_SENTINEL} Just one more thing.`, COMPLETION_SENTINEL],
+      { name: "John", age: 32, birthdate: "1992-01-15" }
+    );
+
+    const r = await generate(model, PersonSchema, "Hii", {}, { turnaround: true });
+    expect(r.status).toBe("collecting");
+    if (r.status !== "collecting") throw new Error("unreachable");
+    expect(r.message).not.toContain(COMPLETION_SENTINEL);
+  });
+
+  it("memory round-trips through JSON — a stateless server can persist and resume it", async () => {
+    const model = mockConversationModel(
+      ["What's your name?", COMPLETION_SENTINEL],
+      { name: "John", age: 32, birthdate: "1992-01-15" }
+    );
+
+    const r1 = await generate(model, PersonSchema, "Hii", {}, { turnaround: true });
+    if (r1.status !== "collecting") throw new Error("unreachable");
+
+    const persisted = JSON.parse(JSON.stringify(r1.memory)) as ConversationMemory;
+    expect(persisted).toEqual(r1.memory);
+
+    const r2 = await generate(model, PersonSchema, "John", {}, { turnaround: true, memory: persisted });
+    expect(r2.status).toBe("complete");
+  });
+
+  it("grounds the model with the schema's required fields, not just prose", async () => {
+    let capturedSystemPrompt = "";
+    const model: ShapecraftModel = {
+      id: "mock:checklist",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        return { name: "John", age: 32, birthdate: "1992-01-15" } as T;
+      },
+      async chat(_messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+        capturedSystemPrompt = systemPrompt ?? "";
+        return "What's your name?";
+      },
+    };
+
+    await generate(model, PersonSchema, "Hii", { systemPrompt: "You are a friendly agent." }, { turnaround: true });
+
+    expect(capturedSystemPrompt).toContain("name");
+    expect(capturedSystemPrompt).toContain("age");
+    expect(capturedSystemPrompt).toContain("birthdate");
+    expect(capturedSystemPrompt).toContain("You are a friendly agent.");
+    expect(capturedSystemPrompt).toContain(COMPLETION_SENTINEL);
+  });
+
+  it("createConversationMemory returns a fresh, empty conversation", () => {
+    const memory = createConversationMemory();
+    expect(memory).toEqual({ messages: [], status: "collecting", turns: 0 });
+  });
+
+  it("throws if a completed conversation is reused", async () => {
+    const model = mockConversationModel([COMPLETION_SENTINEL], { name: "John", age: 32, birthdate: "1992-01-15" });
+    // Not actually completable on turn 1 with an empty transcript in a real scenario,
+    // but we only need a memory object already marked complete to exercise the guard.
+    const completedMemory: ConversationMemory = { messages: [], status: "complete", turns: 1 };
+
+    await expect(
+      generate(model, PersonSchema, "one more thing", {}, { turnaround: true, memory: completedMemory })
+    ).rejects.toThrow(/already completed/);
+  });
+
+  it("non-turnaround generate() is unaffected by the new overload", async () => {
+    const model = mockConversationModel([], { name: "John", age: 32, birthdate: "1992-01-15" });
+    const result = await generate(model, PersonSchema, "extract this");
+    expect(result.data).toEqual({ name: "John", age: 32, birthdate: "1992-01-15" });
+    expect(result.attempts).toBe(1);
+  });
+});


### PR DESCRIPTION
- generate() gets a turnaround: true mode — the LLM asks questions across multiple turns, shapecraft just relays replies, and validates the whole thing once at the end.
- Model decides what to ask (via systemPrompt), we decide when it's actually done — grounded by the schema's required fields, not just prose.
- memory is a plain JSON object, so a stateless web server can persist/rehydrate it between turns.
- Internal errors (extraction failures, retries) never leak into the chat — they throw, never get forwarded as a fake "question."
- Added chat() to all four backends (OpenAI, Groq, Ollama, Anthropic) for the unconstrained conversational calls.

```
generate(model, schema, "Onboarding takes 3 weeks", { systemPrompt: FACILITATOR }, { turnaround: true, memory: r.memory })
// -> { status: "collecting", message: "...", memory } or { status: "complete", data, memory }
```
