### PR TITLE
feat: add streaming support (generateStream) with incremental field validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,44 @@ const local  = ollama({ model: "llama3.2" });
 const claude = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
 ```
 
+## Streaming
+
+`generateStream()` streams tokens live for UX, but validates the assembled response exactly once, through the same pipeline as `generate()` — streaming is purely a transport layer, not a different guarantee. Falls back to one-shot `generate()` for a model without streaming support.
+
+```typescript
+import { generateStream, anthropic } from "@aviasole/shapecraft";
+
+const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+
+const stream = generateStream(model, PersonSchema, "Extract: Jane Doe, 28, jane@example.com");
+
+for await (const delta of stream.textStream) {
+  process.stdout.write(delta); // raw text as it arrives
+}
+
+const { data, attempts, guaranteeLevel } = await stream.result; // validated once, at the end
+```
+
+For lifecycle control (retries, incremental field validation), use `stream.events` instead:
+
+```typescript
+for await (const event of stream2.events) {
+  switch (event.type) {
+    case "attempt-start":   /* a new attempt began */ break;
+    case "delta":           process.stdout.write(event.text); break;
+    case "partial":         console.log("validated so far:", event.value); break;
+    case "attempt-failed":  console.log(`attempt ${event.attempt} failed, retrying`); break;
+    case "done":            console.log(event.result.data); break;
+  }
+}
+```
+
+**`partial` events — incremental per-field validation.** For JSON/Zod object schemas, each top-level field is validated the instant its own value closes in the stream — before the whole object is done — against its own sub-schema (`z.object` shape, or `jsonSchema.properties`). If a field fails, the attempt aborts immediately (no more tokens pulled) and retries fresh, instead of waiting to discover the failure only after the full response arrives. XML, pattern, and custom-validator schemas don't decompose this way — they only emit `delta`/`done`.
+
+**Retries are visible, not silent.** Non-streaming `generate()` retries invisibly — a failed attempt is simply discarded and re-asked. With streaming, tokens have already been shown before validation can run, so a failed attempt can't be un-sent: it emits `attempt-failed` and starts a fresh `attempt-start`. A UI rendering partial text should clear its buffer on `attempt-failed`/`attempt-start`. There's no "only show validated tokens" mode — that would mean waiting for the whole response, which isn't streaming; use non-streaming `generate()` if you need that.
+
+**Streaming smoothness tracks guarantee level.** `native`/`constrained` backends (OpenAI, Groq, Ollama) rarely fail validation — the server already constrains tokens as they're generated — so streams almost never restart. `best-effort` (Anthropic) has no such constraint, so a stream may visibly restart more often.
+
 ## What shapecraft guarantees — and what it doesn't
 
 Every mechanism above (`native`, `constrained`, `best-effort` + retry) targets one thing: **the output is structurally valid** — it parses, the types match, required fields are present and non-empty. That's a real, load-bearing guarantee: it's the difference between code that can trust `result.data.age` is a `number` versus code that has to defensively re-check everything the model says.

--- a/examples/stream.ts
+++ b/examples/stream.ts
@@ -1,0 +1,61 @@
+/**
+ * Example: generateStream — streamed structured output.
+ *
+ * Tokens stream live for UX, but validation still happens exactly once, on
+ * the fully assembled response — streaming is purely a transport layer over
+ * the same pipeline as non-streaming generate(). For JSON/Zod object
+ * schemas, each top-level field is ALSO validated the moment its own JSON
+ * closes (before the whole object is done), via "partial" events — so a UI
+ * can render fields as they arrive, already validated.
+ */
+import { generateStream, anthropic } from "@aviasole/shapecraft";
+
+const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+
+const schema = {
+  jsonSchema: {
+    type: "object",
+    required: ["name", "age", "email"],
+    properties: {
+      name: { type: "string" },
+      age: { type: "number" },
+      email: { type: "string" },
+    },
+  },
+};
+
+// ── Simple: just show tokens, then get the validated object ─────────────────
+const stream = generateStream(model, schema, "Extract: Jane Doe, 28, jane@example.com");
+
+for await (const delta of stream.textStream) {
+  process.stdout.write(delta);
+}
+
+const { data, attempts, guaranteeLevel } = await stream.result;
+console.log("\n", { data, attempts, guaranteeLevel });
+// { data: { name: "Jane Doe", age: 28, email: "jane@example.com" }, attempts: 1, guaranteeLevel: "best-effort" }
+
+// ── Richer: react to lifecycle events, including incremental field validation ─
+const stream2 = generateStream(model, schema, "Extract: John Smith, 41, john@example.com");
+
+for await (const event of stream2.events) {
+  switch (event.type) {
+    case "attempt-start":
+      console.log(`\n--- attempt ${event.attempt} ---`);
+      break;
+    case "delta":
+      process.stdout.write(event.text);
+      break;
+    case "partial":
+      // Fires the instant each top-level field closes, already validated
+      // against its own sub-schema — no need to wait for the whole object.
+      console.log("\npartial so far:", event.value);
+      break;
+    case "attempt-failed":
+      console.log(`\nattempt ${event.attempt} failed validation, retrying...`);
+      break;
+    case "done":
+      console.log("\ndone:", event.result.data);
+      break;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "0.1.3",
+  "version": "2.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "0.1.3",
+      "version": "2.0.1",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "0.1.3",
+  "version": "2.0.1",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -53,5 +53,24 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
 
       return response.content[0]?.type === "text" ? response.content[0].text : "";
     },
+
+    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+      const anthropicClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = anthropicClient.messages.stream({
+        model: modelId,
+        max_tokens: 4096,
+        system,
+        messages: [{ role: "user", content: user }],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const event of stream as AsyncIterable<any>) {
+        if (event.type === "content_block_delta" && event.delta?.type === "text_delta") {
+          yield event.delta.text as string;
+        }
+      }
+    },
   };
 }

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -57,5 +57,26 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
 
       return response.choices[0]?.message?.content ?? "";
     },
+
+    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+      const groqClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = await groqClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
+        stream: true,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) yield delta;
+      }
+    },
   };
 }

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -10,6 +10,19 @@ export interface OllamaBackendOptions {
   timeoutMs?: number;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function formatFor(schema: SchemaInput): any {
+  // Pass JSON schema to Ollama's format param for constrained decoding when possible
+  if (isZodSchema(schema)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return toJsonSchema(schema as z.ZodType<any>);
+  }
+  if ("jsonSchema" in (schema as object)) {
+    return (schema as { jsonSchema: Record<string, unknown> }).jsonSchema;
+  }
+  return undefined;
+}
+
 export function ollama(options: OllamaBackendOptions): ShapecraftModel {
   const host = options.host ?? "http://localhost:11434";
   const timeoutMs = options.timeoutMs ?? 120_000;
@@ -20,14 +33,7 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
-
-      // Pass JSON schema to Ollama's format param for constrained decoding when possible
-      let format: unknown = undefined;
-      if (isZodSchema(schema)) {
-        format = toJsonSchema(schema as z.ZodType<any>);
-      } else if ("jsonSchema" in (schema as object)) {
-        format = (schema as { jsonSchema: Record<string, unknown> }).jsonSchema;
-      }
+      const format = formatFor(schema);
 
       const response = await fetch(`${host}/api/chat`, {
         signal: AbortSignal.timeout(timeoutMs),
@@ -75,6 +81,59 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
 
       const json = (await response.json()) as { message?: { content?: string } };
       return json.message?.content ?? "";
+    },
+
+    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+      const format = formatFor(schema);
+
+      const response = await fetch(`${host}/api/chat`, {
+        signal: AbortSignal.timeout(timeoutMs),
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: options.model,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          ...(format ? { format } : {}),
+          stream: true,
+        }),
+      });
+
+      if (!response.ok || !response.body) {
+        throw new Error(`Ollama error: ${response.status} ${response.statusText}`);
+      }
+
+      // Ollama streams NDJSON — one JSON object per line, last line has done: true.
+      const reader = response.body.getReader();
+      const decoder = new TextDecoder();
+      let ndjsonBuffer = "";
+
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          ndjsonBuffer += decoder.decode(value, { stream: true });
+
+          let newlineIndex: number;
+          while ((newlineIndex = ndjsonBuffer.indexOf("\n")) !== -1) {
+            const line = ndjsonBuffer.slice(0, newlineIndex).trim();
+            ndjsonBuffer = ndjsonBuffer.slice(newlineIndex + 1);
+            if (!line) continue;
+
+            const chunk = JSON.parse(line) as { message?: { content?: string }; done?: boolean };
+            if (chunk.message?.content) yield chunk.message.content;
+            if (chunk.done) return;
+          }
+        }
+      } finally {
+        // Runs even on early exit (e.g. the consumer breaks out of a
+        // for-await loop, which calls this generator's return()) — releases
+        // the underlying stream instead of leaking a locked reader.
+        reader.releaseLock();
+      }
     },
   };
 }

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -10,6 +10,23 @@ export interface OpenAIBackendOptions {
   baseURL?: string;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function responseFormatFor(schema: SchemaInput): any {
+  // Strict json_schema mode for Zod, non-strict for raw jsonSchema, json_object otherwise
+  return isZodSchema(schema)
+    ? {
+        type: "json_schema" as const,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        json_schema: { name: "output", strict: true, schema: toJsonSchema(schema as z.ZodType<any>) },
+      }
+    : "jsonSchema" in (schema as object)
+      ? {
+          type: "json_schema" as const,
+          json_schema: { name: "output", strict: false, schema: (schema as { jsonSchema: Record<string, unknown> }).jsonSchema },
+        }
+      : { type: "json_object" as const };
+}
+
 export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
   const modelId = options.model ?? "gpt-4o-mini";
 
@@ -31,26 +48,13 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
       const openaiClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      // Use strict json_schema mode for Zod, non-strict for raw jsonSchema, json_object otherwise
-      const responseFormat = isZodSchema(schema)
-        ? {
-            type: "json_schema" as const,
-            json_schema: { name: "output", strict: true, schema: toJsonSchema(schema as z.ZodType<any>) },
-          }
-        : "jsonSchema" in (schema as object)
-          ? {
-              type: "json_schema" as const,
-              json_schema: { name: "output", strict: false, schema: (schema as { jsonSchema: Record<string, unknown> }).jsonSchema },
-            }
-          : { type: "json_object" as const };
-
       const response = await openaiClient.chat.completions.create({
         model: modelId,
         messages: [
           { role: "system", content: system },
           { role: "user", content: user },
         ],
-        response_format: responseFormat,
+        response_format: responseFormatFor(schema),
       });
 
       const raw: string = response.choices[0]?.message?.content ?? "";
@@ -70,6 +74,27 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
       });
 
       return response.choices[0]?.message?.content ?? "";
+    },
+
+    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+      const openaiClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = await openaiClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          { role: "system", content: system },
+          { role: "user", content: user },
+        ],
+        response_format: responseFormatFor(schema),
+        stream: true,
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) yield delta;
+      }
     },
   };
 }

--- a/src/core/incremental.ts
+++ b/src/core/incremental.ts
@@ -1,0 +1,181 @@
+import { z } from "zod";
+import type { SchemaInput } from "../types.js";
+import { checkJsonSchema, isXmlInput } from "./validate.js";
+
+/**
+ * Scans a growing JSON buffer for top-level object fields whose value has
+ * fully closed syntactically (string/number/bool/null terminated, or a
+ * nested object/array's matching bracket reached at depth 0), and returns
+ * their raw JSON text. Fields still being written are skipped — they'll show
+ * up on a later call once complete. Only understands an object at the root;
+ * any other root shape (array, XML, plain string) returns {} immediately,
+ * which is the correct "not applicable" result for those schema types.
+ *
+ * This gives field-level completion boundaries without a full recursive
+ * parse — nested content inside a field's value is treated as an opaque
+ * blob (validated as a whole once that field closes), not decomposed further.
+ */
+export function extractCompletedTopLevelFields(buffer: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const n = buffer.length;
+  let i = 0;
+
+  const skipWs = () => {
+    while (i < n && /\s/.test(buffer[i]!)) i++;
+  };
+
+  // Find the first '{' anywhere, not just at position 0 — a best-effort backend
+  // may wrap the object in prose or a ```json fence (the same tolerance the
+  // final extractJson step already applies). A stray '{' in unrelated prose
+  // is harmless: the very next check requires a '"' key start immediately
+  // after it, which ordinary text won't satisfy, so scanning just yields {}.
+  const braceIndex = buffer.indexOf("{");
+  if (braceIndex === -1) return result;
+  i = braceIndex + 1;
+
+  while (i < n) {
+    skipWs();
+    if (i >= n || buffer[i] === "}") break;
+    if (buffer[i] !== '"') break; // not at a key start -> nothing more is complete yet
+
+    const keyStart = i;
+    i++;
+    let escaped = false;
+    while (i < n) {
+      if (buffer[i] === "\\" && !escaped) {
+        escaped = true;
+        i++;
+        continue;
+      }
+      if (buffer[i] === '"' && !escaped) break;
+      escaped = false;
+      i++;
+    }
+    if (i >= n) break; // key string not yet closed
+    const keyEnd = i;
+    i++;
+    const key = JSON.parse(buffer.slice(keyStart, keyEnd + 1)) as string;
+
+    skipWs();
+    if (buffer[i] !== ":") break; // colon not yet written
+    i++;
+    skipWs();
+    if (i >= n) break;
+
+    const valueStart = i;
+    let valueEnd = -1;
+
+    if (buffer[i] === '"') {
+      i++;
+      let esc = false;
+      let closed = false;
+      while (i < n) {
+        if (buffer[i] === "\\" && !esc) {
+          esc = true;
+          i++;
+          continue;
+        }
+        if (buffer[i] === '"' && !esc) {
+          closed = true;
+          i++;
+          break;
+        }
+        esc = false;
+        i++;
+      }
+      if (!closed) break;
+      valueEnd = i;
+    } else if (buffer[i] === "{" || buffer[i] === "[") {
+      const open = buffer[i];
+      const close = open === "{" ? "}" : "]";
+      let depth = 0;
+      let esc = false;
+      let inStr = false;
+      let closed = false;
+      while (i < n) {
+        const c = buffer[i];
+        if (inStr) {
+          if (c === "\\" && !esc) {
+            esc = true;
+            i++;
+            continue;
+          }
+          if (c === '"' && !esc) inStr = false;
+          esc = false;
+          i++;
+          continue;
+        }
+        if (c === '"') {
+          inStr = true;
+          i++;
+          continue;
+        }
+        if (c === open) depth++;
+        else if (c === close) {
+          depth--;
+          if (depth === 0) {
+            i++;
+            closed = true;
+            break;
+          }
+        }
+        i++;
+      }
+      if (!closed) break;
+      valueEnd = i;
+    } else {
+      // number / true / false / null — needs a terminator to be sure it's
+      // not still growing (e.g. "3" could still become "30").
+      while (i < n && !/[,}\s]/.test(buffer[i]!)) i++;
+      if (i >= n) break;
+      valueEnd = i;
+    }
+
+    result[key] = buffer.slice(valueStart, valueEnd);
+
+    skipWs();
+    if (buffer[i] === ",") {
+      i++;
+      continue;
+    }
+    break; // "}" (object done) or anything else — stop scanning this pass
+  }
+
+  return result;
+}
+
+/**
+ * Validates one field's value against its own sub-schema, if the root
+ * schema decomposes into named fields (Zod object, or jsonSchema with
+ * `properties`). Returns an error message on failure, or null if the field
+ * passed (or there's no sub-schema for it / for this schema type at all —
+ * XML, pattern, and custom-validator schemas never decompose).
+ */
+export function validateFieldIfPossible<T>(schema: SchemaInput<T>, key: string, value: unknown): string | null {
+  if (isXmlInput(schema)) return null;
+
+  if (schema instanceof z.ZodType) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shape = (schema as any).shape as Record<string, z.ZodTypeAny> | undefined;
+    const fieldSchema = shape?.[key];
+    if (!fieldSchema) return null;
+    const result = fieldSchema.safeParse(value);
+    return result.success ? null : `Field "${key}" failed schema validation: ${result.error.message}`;
+  }
+
+  if ("jsonSchema" in (schema as object)) {
+    const properties = (schema as { jsonSchema: Record<string, unknown> }).jsonSchema.properties as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    const propSchema = properties?.[key];
+    if (!propSchema) return null;
+    try {
+      checkJsonSchema(value, propSchema);
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  return null; // pattern / custom validator schemas — no per-field decomposition
+}

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -1,0 +1,191 @@
+import type { GenerateOptions, GenerateResult, SchemaInput, ShapecraftModel, StreamEvent, StreamHandle } from "../types.js";
+import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
+import { generate } from "./generate.js";
+import { parseAndValidate } from "./parse.js";
+import { extractCompletedTopLevelFields, validateFieldIfPossible } from "./incremental.js";
+
+/**
+ * Single-consumer async channel. textStream and events are two independent
+ * channels fed by the same pump — each is meant to be iterated by at most one
+ * consumer, matching how streamGenerate()'s two views are actually used.
+ */
+function createChannel<T>(): { push(item: T): void; end(): void; iterable: AsyncIterable<T> } {
+  const buffer: T[] = [];
+  let ended = false;
+  let waiting: ((result: IteratorResult<T>) => void) | null = null;
+
+  function push(item: T): void {
+    if (ended) return;
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve({ value: item, done: false });
+    } else {
+      buffer.push(item);
+    }
+  }
+
+  function end(): void {
+    if (ended) return;
+    ended = true;
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve({ value: undefined as unknown as T, done: true });
+    }
+  }
+
+  const iterable: AsyncIterable<T> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (buffer.length > 0) return Promise.resolve({ value: buffer.shift() as T, done: false });
+          if (ended) return Promise.resolve({ value: undefined as unknown as T, done: true });
+          return new Promise((resolve) => {
+            waiting = resolve;
+          });
+        },
+      };
+    },
+  };
+
+  return { push, end, iterable };
+}
+
+export function generateStream<T>(
+  model: ShapecraftModel,
+  schema: SchemaInput<T>,
+  prompt: string,
+  options: GenerateOptions = {}
+): StreamHandle<T> {
+  const maxRetries = options.maxRetries ?? 3;
+  const { systemPrompt } = options;
+
+  const textChannel = createChannel<string>();
+  const eventChannel = createChannel<StreamEvent<T>>();
+
+  let resolveResult!: (result: GenerateResult<T>) => void;
+  let rejectResult!: (error: unknown) => void;
+  const result = new Promise<GenerateResult<T>>((resolve, reject) => {
+    resolveResult = resolve;
+    rejectResult = reject;
+  });
+
+  function emit(event: StreamEvent<T>): void {
+    eventChannel.push(event);
+    if (event.type === "delta") textChannel.push(event.text);
+  }
+
+  function finish(): void {
+    eventChannel.end();
+    textChannel.end();
+  }
+
+  async function pump(): Promise<void> {
+    // No streaming support on this model — fall back to one-shot generate(),
+    // and surface its full output as a single delta so textStream still works.
+    if (!model.generateStream) {
+      emit({ type: "attempt-start", attempt: 1 });
+      const finalResult = await generate<T>(model, schema, prompt, options);
+      const text = typeof finalResult.data === "string" ? finalResult.data : JSON.stringify(finalResult.data, null, 2);
+      emit({ type: "delta", text, attempt: 1 });
+      emit({ type: "done", result: finalResult });
+      finish();
+      resolveResult(finalResult);
+      return;
+    }
+
+    for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      emit({ type: "attempt-start", attempt });
+      let buffer = "";
+      const validatedKeys = new Set<string>();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const partialValue: Record<string, unknown> = {};
+      let earlyFailure: SchemaViolationError | null = null;
+
+      try {
+        for await (const delta of model.generateStream<T>(prompt, schema, systemPrompt)) {
+          buffer += delta;
+          emit({ type: "delta", text: delta, attempt });
+
+          // Incremental per-field validation: the moment a top-level field's
+          // JSON closes, check it against its own sub-schema immediately,
+          // instead of waiting for the whole object. Only applies to schemas
+          // that decompose into named fields (Zod object / jsonSchema with
+          // properties) — everything else is a no-op here.
+          const completedFields = extractCompletedTopLevelFields(buffer);
+          for (const [key, raw] of Object.entries(completedFields)) {
+            if (validatedKeys.has(key)) continue;
+            validatedKeys.add(key);
+
+            let value: unknown;
+            try {
+              value = JSON.parse(raw);
+            } catch {
+              continue; // shouldn't happen — the scanner only returns syntactically closed values
+            }
+
+            const fieldError = validateFieldIfPossible(schema, key, value);
+            if (fieldError) {
+              earlyFailure = new SchemaViolationError(buffer, { field: key, error: fieldError });
+              break;
+            }
+
+            partialValue[key] = value;
+            emit({ type: "partial", value: { ...partialValue } as Partial<T>, attempt });
+          }
+
+          if (earlyFailure) break; // stop consuming further deltas — no point streaming a doomed attempt
+        }
+      } catch (err) {
+        // Transport/network error (or a synchronous validation throw, e.g. a bad
+        // XML template) — not a SchemaViolationError, so it is never retried.
+        finish();
+        rejectResult(err);
+        return;
+      }
+
+      if (earlyFailure) {
+        emit({ type: "attempt-failed", attempt, error: earlyFailure });
+        if (attempt === maxRetries) {
+          finish();
+          rejectResult(new MaxRetriesExceededError(maxRetries));
+          return;
+        }
+        continue; // next attempt streams fresh
+      }
+
+      try {
+        // extractJson: true is safe unconditionally — for a clean JSON buffer
+        // the extraction regex matches the whole string (no-op); for a
+        // best-effort backend that wraps JSON in prose, it's required.
+        const data = parseAndValidate<T>(buffer, schema, { extractJson: true });
+        const finalResult: GenerateResult<T> = { data, guaranteeLevel: model.guaranteeLevel, attempts: attempt };
+        emit({ type: "done", result: finalResult });
+        finish();
+        resolveResult(finalResult);
+        return;
+      } catch (err) {
+        if (!(err instanceof SchemaViolationError)) {
+          finish();
+          rejectResult(err);
+          return;
+        }
+        emit({ type: "attempt-failed", attempt, error: err });
+        if (attempt === maxRetries) {
+          finish();
+          rejectResult(new MaxRetriesExceededError(maxRetries));
+          return;
+        }
+        // else: loop continues, next attempt streams fresh
+      }
+    }
+  }
+
+  pump().catch((err) => {
+    finish();
+    rejectResult(err);
+  });
+
+  return { textStream: textChannel.iterable, events: eventChannel.iterable, result };
+}

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -22,7 +22,7 @@ function nullToUndefined(value: unknown): unknown {
   return value;
 }
 
-function checkJsonSchema(value: unknown, schema: Record<string, unknown>): void {
+export function checkJsonSchema(value: unknown, schema: Record<string, unknown>): void {
   const type = schema.type as string | undefined;
 
   if (type) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { generate } from "./core/generate.js";
+export { generateStream } from "./core/stream.js";
 export { toJsonSchema, buildStructuredPrompt } from "./core/schema.js";
 export { xmlType, validateXmlTemplate } from "./core/xml.js";
 export { createConversationMemory, COMPLETION_SENTINEL } from "./core/turnaround.js";
@@ -16,6 +17,8 @@ export type {
   ConversationMemory,
   TurnaroundOptions,
   TurnResult,
+  StreamEvent,
+  StreamHandle,
 } from "./types.js";
 
 export { SchemaViolationError, MaxRetriesExceededError, MaxTurnsExceededError } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -45,6 +45,13 @@ export interface ShapecraftModel {
    * Required for `turnaround: true` — models without it throw when used that way.
    */
   chat?(messages: ChatMessage[], systemPrompt?: string): Promise<string>;
+  /**
+   * Yields RAW text deltas only — no parsing/validation. `generateStream()`
+   * (the core entry point) accumulates these and validates the assembled
+   * buffer through the same pipeline as non-streaming `generate()`.
+   * Absence ⇒ the core falls back to one-shot `generate()`.
+   */
+  generateStream?<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string>;
 }
 
 export interface GenerateOptions {
@@ -101,3 +108,27 @@ export interface TurnaroundOptions {
 export type TurnResult<T> =
   | { status: "collecting"; message: string; memory: ConversationMemory }
   | { status: "complete"; data: T; memory: ConversationMemory };
+
+export type StreamEvent<T> =
+  | { type: "attempt-start"; attempt: number }
+  | { type: "delta"; text: string; attempt: number }
+  /**
+   * A top-level field just closed and passed its own sub-schema check —
+   * `value` accumulates validated fields so far. Only emitted for schemas
+   * shaped as a JSON object at the root (Zod object / jsonSchema with
+   * `properties`); other schema types never emit this. Nested fields inside
+   * a top-level field are not individually validated — the whole field's
+   * value is checked once its own JSON closes.
+   */
+  | { type: "partial"; value: Partial<T>; attempt: number }
+  | { type: "attempt-failed"; attempt: number; error: SchemaViolationError }
+  | { type: "done"; result: GenerateResult<T> };
+
+export interface StreamHandle<T> {
+  /** Raw text deltas as they arrive (concatenation of all attempts — see README). */
+  textStream: AsyncIterable<string>;
+  /** Structured lifecycle events: deltas, attempt boundaries, retries, done. */
+  events: AsyncIterable<StreamEvent<T>>;
+  /** Resolves with the final validated result, or rejects with MaxRetriesExceededError. */
+  result: Promise<GenerateResult<T>>;
+}

--- a/tests/stream.test.ts
+++ b/tests/stream.test.ts
@@ -1,0 +1,270 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { generateStream } from "../src/core/stream.js";
+import { buildStructuredPrompt } from "../src/core/schema.js";
+import { anthropic } from "../src/backends/anthropic.js";
+import { groq } from "../src/backends/groq.js";
+import { ollama } from "../src/backends/ollama.js";
+import { MaxRetriesExceededError } from "../src/types.js";
+import type { SchemaInput, ShapecraftModel, StreamEvent } from "../src/types.js";
+import { mockModel } from "./helpers/index.js";
+
+const PersonSchema = z.object({
+  name: z.string(),
+  age: z.number(),
+});
+
+const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
+const hasGroq = !!process.env.GROQ_API_KEY;
+const hasOllama = !!process.env.OLLAMA_MODEL;
+const ollamaModel = process.env.OLLAMA_MODEL ?? "nemotron-3-super:cloud";
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+/** One scripted chunk array per attempt; each generateStream() call consumes the next. */
+function mockStreamingModel(chunksPerAttempt: string[][]): ShapecraftModel {
+  let attemptIndex = 0;
+  return {
+    id: "mock:stream",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      throw new Error("generate() should not be called directly in these tests");
+    },
+    async *generateStream<T>(): AsyncIterable<string> {
+      const chunks = chunksPerAttempt[attemptIndex];
+      attemptIndex++;
+      if (!chunks) throw new Error("mock exhausted: no scripted chunks for this attempt");
+      for (const chunk of chunks) yield chunk;
+    },
+  } as ShapecraftModel;
+}
+
+/** Mirrors a real backend: calls buildStructuredPrompt inside generateStream(), so a
+ * bad XML template throws synchronously before any delta, exactly like production. */
+function mockXmlAwareStreamingModel(): ShapecraftModel {
+  return {
+    id: "mock:xml-stream",
+    guaranteeLevel: "constrained",
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
+      buildStructuredPrompt(prompt, schema, systemPrompt);
+      return {} as T;
+    },
+    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+      buildStructuredPrompt(prompt, schema, systemPrompt); // throws synchronously for a bad template
+      yield "<book></book>";
+    },
+  };
+}
+
+describe("generateStream", () => {
+  it("streams deltas that accumulate to the full output, then resolves the validated result", async () => {
+    const model = mockStreamingModel([['{"name":', '"Alice",', '"age":30}']]);
+    const stream = generateStream(model, PersonSchema, "extract");
+
+    const [textParts, events, result] = await Promise.all([collect(stream.textStream), collect(stream.events), stream.result]);
+
+    expect(textParts.join("")).toBe('{"name":"Alice","age":30}');
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+    expect(result.attempts).toBe(1);
+    expect(result.guaranteeLevel).toBe("constrained");
+    // Non-partial lifecycle events, in order (partial events are covered separately below).
+    expect(events.filter((e) => e.type !== "partial").map((e) => e.type)).toEqual(["attempt-start", "delta", "delta", "delta", "done"]);
+  });
+
+  it("retries on validation failure: streams fresh on the next attempt and reports attempts correctly", async () => {
+    const model = mockStreamingModel([
+      ['{"name":"Alice"}'], // attempt 1: missing required "age" -> SchemaViolationError
+      ['{"name":"Alice","age":30}'], // attempt 2: valid
+    ]);
+    const stream = generateStream(model, PersonSchema, "extract");
+
+    const events = await collect(stream.events);
+    const result = await stream.result;
+
+    expect(result.attempts).toBe(2);
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+
+    const types = events.filter((e) => e.type !== "partial").map((e) => e.type);
+    expect(types).toEqual(["attempt-start", "delta", "attempt-failed", "attempt-start", "delta", "done"]);
+
+    const failedEvent = events.find((e): e is Extract<StreamEvent<unknown>, { type: "attempt-failed" }> => e.type === "attempt-failed");
+    expect(failedEvent?.attempt).toBe(1);
+  });
+
+  it("exhausting all retries rejects result with MaxRetriesExceededError", async () => {
+    const model = mockStreamingModel([['{"name":"Alice"}'], ['{"name":"Bob"}'], ['{"name":"Cara"}']]);
+    const stream = generateStream(model, PersonSchema, "extract", { maxRetries: 3 });
+
+    await expect(stream.result).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("falls back to one-shot generate() for a model without generateStream, emitting one delta", async () => {
+    const model = mockModel({ name: "Alice", age: 30 });
+    const stream = generateStream(model, PersonSchema, "extract");
+
+    const [textParts, events, result] = await Promise.all([collect(stream.textStream), collect(stream.events), stream.result]);
+
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+    expect(result.attempts).toBe(1);
+    expect(textParts).toHaveLength(1);
+    expect(JSON.parse(textParts[0])).toEqual({ name: "Alice", age: 30 });
+    expect(events.map((e) => e.type)).toEqual(["attempt-start", "delta", "done"]);
+  });
+
+  it("a bad XML template rejects before any delta is emitted — same fail-fast as generate()", async () => {
+    const model = mockXmlAwareStreamingModel();
+    const badSchema = { xml: { template: "<book>{garbled}</book>" } };
+    const stream = generateStream(model, badSchema, "extract");
+
+    const textPartsPromise = collect(stream.textStream);
+    await expect(stream.result).rejects.toThrow(/Invalid placeholder/);
+    expect(await textPartsPromise).toEqual([]);
+  });
+
+  it("a transport error mid-stream rejects immediately and is not retried", async () => {
+    const model: ShapecraftModel = {
+      id: "mock:transport-fail",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        throw new Error("should not be called");
+      },
+      async *generateStream<T>(): AsyncIterable<string> {
+        yield '{"name":';
+        throw new Error("network failure");
+      },
+    };
+
+    const stream = generateStream(model, PersonSchema, "extract", { maxRetries: 3 });
+    await expect(stream.result).rejects.toThrow("network failure");
+
+    const events = await collect(stream.events);
+    // Only one attempt-start — the transport error must not trigger a retry.
+    expect(events.filter((e) => e.type === "attempt-start")).toHaveLength(1);
+  });
+
+  it("textStream and events observe the exact same delta text and ordering", async () => {
+    const model = mockStreamingModel([['{"na', 'me":"Alice","age":30}']]);
+    const stream = generateStream(model, PersonSchema, "extract");
+
+    const [textParts, events] = await Promise.all([collect(stream.textStream), collect(stream.events)]);
+    const deltaTextFromEvents = events.filter((e) => e.type === "delta").map((e) => (e as { text: string }).text);
+
+    expect(textParts).toEqual(deltaTextFromEvents);
+  });
+
+  it("emits a validated partial object the moment each top-level field closes, before the stream ends", async () => {
+    const model = mockStreamingModel([['{"name":"Alice",', '"age":30}']]);
+    const stream = generateStream(model, PersonSchema, "extract");
+
+    const events = await collect(stream.events);
+    const partials = events
+      .filter((e): e is Extract<StreamEvent<{ name: string; age: number }>, { type: "partial" }> => e.type === "partial")
+      .map((e) => e.value);
+
+    // "name" closes after the first delta; "age" closes after the second —
+    // each partial should already be validated (not raw/unchecked).
+    expect(partials).toEqual([{ name: "Alice" }, { name: "Alice", age: 30 }]);
+
+    // Partial events must arrive strictly before "done" — that's the whole point.
+    const partialIndex = events.findIndex((e) => e.type === "partial");
+    const doneIndex = events.findIndex((e) => e.type === "done");
+    expect(partialIndex).toBeGreaterThanOrEqual(0);
+    expect(partialIndex).toBeLessThan(doneIndex);
+  });
+
+  it("aborts an attempt early on the first invalid field instead of streaming the rest", async () => {
+    let consumedChunks = 0;
+    const chunks = ['{"name":"Alice","age":"not-a-number",', '"extra":"never consumed"}'];
+    const model: ShapecraftModel = {
+      id: "mock:early-abort",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        throw new Error("should not be called");
+      },
+      async *generateStream<T>(): AsyncIterable<string> {
+        for (const chunk of chunks) {
+          consumedChunks++;
+          yield chunk;
+        }
+      },
+    };
+
+    const stream = generateStream(model, PersonSchema, "extract", { maxRetries: 1 });
+    await expect(stream.result).rejects.toBeInstanceOf(MaxRetriesExceededError);
+
+    // The second chunk (with "extra") should never have been pulled — the
+    // scanner caught the bad "age" field inside the first chunk and aborted.
+    expect(consumedChunks).toBe(1);
+  });
+});
+
+describe("generateStream — Anthropic backend (real API)", () => {
+  it.skipIf(!hasAnthropic)("streams real deltas that accumulate to a validated object", async () => {
+    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+    const stream = generateStream(model, PersonSchema, "Extract: Jane Doe, 28 years old.");
+
+    const textParts = await collect(stream.textStream);
+    const result = await stream.result;
+
+    expect(textParts.join("").length).toBeGreaterThan(0);
+    expect(result.data.name).toBeTruthy();
+    expect(result.data.age).toBeGreaterThan(0);
+  });
+
+  // Real token boundaries are irregular (unlike scripted mock chunks) — this is
+  // the actual stress test for the incremental field-boundary scanner.
+  it.skipIf(!hasAnthropic)("emits real incremental partial fields ahead of the final done event", async () => {
+    const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+    const stream = generateStream(model, PersonSchema, "Extract: Jane Doe, 28 years old.");
+
+    const events = await collect(stream.events);
+    const result = await stream.result;
+
+    const partials = events.filter((e) => e.type === "partial");
+    expect(partials.length).toBeGreaterThan(0);
+
+    const doneIndex = events.findIndex((e) => e.type === "done");
+    for (const p of partials) {
+      expect(events.indexOf(p)).toBeLessThan(doneIndex);
+    }
+
+    // Every field that ever showed up in a partial must match the final result —
+    // incremental validation must never disagree with the final whole-object check.
+    const lastPartial = partials[partials.length - 1] as { value: Record<string, unknown> };
+    for (const [key, value] of Object.entries(lastPartial.value)) {
+      expect((result.data as Record<string, unknown>)[key]).toEqual(value);
+    }
+  });
+});
+
+describe("generateStream — Groq backend (real API)", () => {
+  it.skipIf(!hasGroq)("streams real deltas that accumulate to a validated object", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const stream = generateStream(model, PersonSchema, "Extract: Jane Doe, 28 years old.");
+
+    const textParts = await collect(stream.textStream);
+    const result = await stream.result;
+
+    expect(textParts.join("").length).toBeGreaterThan(0);
+    expect(result.data.name).toBeTruthy();
+    expect(result.data.age).toBeGreaterThan(0);
+  });
+});
+
+describe("generateStream — Ollama backend (real API)", () => {
+  it.skipIf(!hasOllama)("streams real NDJSON deltas that accumulate to a validated object", async () => {
+    const model = ollama({ model: ollamaModel, timeoutMs: 120_000 });
+    const stream = generateStream(model, PersonSchema, "Extract: Jane Doe, 28 years old.");
+
+    const textParts = await collect(stream.textStream);
+    const result = await stream.result;
+
+    expect(textParts.join("").length).toBeGreaterThan(0);
+    expect(result.data.name).toBeTruthy();
+    expect(result.data.age).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
- New generateStream() — tokens stream live, but validation still runs once on the fully assembled response, through the same pipeline as generate().
- For JSON/Zod object schemas, each top-level field is also validated the instant its own JSON closes (before the whole object finishes) — early-abort on a bad field instead of streaming the rest of a doomed attempt.
- Retries stream fresh on validation failure (visible restart), same retry semantics as non-streaming generate().
- Added generateStream() to all four backends (OpenAI, Groq, Ollama, Anthropic); falls back to one-shot generate() for models without it.

```
const stream = generateStream(model, schema, "Extract: Jane Doe, 28, jane@example.com");

for await (const event of stream.events) {
  if (event.type === "partial") console.log("field validated so far:", event.value);
}

const { data } = await stream.result; // validated once, at the end
```
