### PR TITLE
Add createClient(), timeouts/abort, result metadata, pluggable validator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [2.0.2] - 2026-07-06
+
+### Added
+- **`createClient()` + middleware pipeline** — `createClient({ middleware, retry, timeoutMs, jsonSchemaValidator })`
+  wraps `generate()`/`generateStream()` with a Koa-style onion middleware chain
+  (`composeMiddleware`, `loggingMiddleware` exported) for logging/caching/telemetry.
+  Purely additive: existing direct calls to `generate()`/`generateStream()` are
+  completely unaffected — this is a new, optional entry point, not a replacement.
+- **`GenerateResult.metadata`** — every result now includes
+  `{ provider, model, latencyMs, tokens?, finishReason?, requestId?, cost? }`.
+  `provider`/`model`/`latencyMs` are always populated by the core; the rest stay
+  `undefined` until a backend opts in to supplying them.
+- **`timeoutMs` / `signal` on `GenerateOptions`** — a single attempt can now be
+  bounded by a timeout or cancelled via `AbortSignal`, surfaced as the new
+  `TimeoutError`. Enforced at the core level for every backend (the retry loop
+  always stops waiting), and threaded through to all four built-in backends
+  for real request cancellation, not just abandonment.
+- **Pluggable `jsonSchemaValidator`** — override the built-in shallow
+  `{ jsonSchema }` structural check (e.g. swap in AJV) via
+  `GenerateOptions.jsonSchemaValidator`. Applies to both `generate()`'s final
+  check and `generateStream()`'s per-field incremental validation. Omitting it
+  keeps today's built-in `checkJsonSchema` behavior unchanged.
+- `ModelCallOptions` — new optional 4th parameter on `ShapecraftModel.generate()`/
+  `generateStream()` carrying `{ signal }`. Backends that don't declare it still
+  satisfy the interface and behave exactly as before.
+
+### Notes
+- `createClient()`'s middleware wraps `generate()` only; `generateStream()` gets
+  the client's retry/timeout/validator defaults but not middleware interception
+  (its async-iterable shape doesn't fit the simple before/after model — see the
+  streaming-parser-refactor item in PLAN-Updated.md). `turnaround` calls are also
+  out of scope for the client wrapper in v1 — use top-level
+  `generate(..., { turnaround: true })`.
+- This branch (`architecture-hardening`) was cut from `main` at the stream-support
+  merge point, independent of the (still unmerged) fhir-support/gbnf-support
+  branches — those lineages will need reconciling on merge.
+
+## [2.0.1] - 2026-07-04
+
+### Added
+- `generateStream()` — streams tokens live for UX while validating the assembled
+  response exactly once, through the same pipeline as `generate()`.
+- `StreamHandle` with two independent views: `textStream` (raw text deltas) and
+  `events` (full lifecycle: `attempt-start`, `delta`, `partial`, `attempt-failed`, `done`).
+- Incremental per-field validation (`partial` events) — for JSON/Zod object schemas,
+  each top-level field is validated the instant its own value closes in the stream,
+  before the whole object finishes.
+- Visible retries — a streaming attempt that fails validation emits `attempt-failed`
+  and starts a fresh `attempt-start`, since already-streamed tokens can't be un-sent.
+- `generateStream()` added to all four backends (openai, groq, anthropic, ollama),
+  falling back to one-shot `generate()` for a model without native streaming support.
+- `checkJsonSchema` exported from `core/validate.ts` for reuse by the incremental validator.
+
 ## [0.1.0] - 2026-06-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,16 @@
   `generateStream()` carrying `{ signal }`. Backends that don't declare it still
   satisfy the interface and behave exactly as before.
 
+### Fixed
+- **`isZodSchema()` dual-package-hazard** — replaced `schema instanceof z.ZodType`
+  with a duck-typed check (`_def` + `parse`/`safeParse`). A consumer whose zod
+  install resolves to a different module instance or major version than the one
+  in shapecraft's own dependency tree (e.g. a `file:`-linked local package, or a
+  nested zod copy pulled in transitively by another dependency) would silently
+  hit "Unknown schema type" for every Zod schema, since `instanceof` compared
+  against the wrong class. Affected `core/validate.ts`, `core/schema.ts`,
+  `core/incremental.ts`, `core/turnaround.ts`.
+
 ### Notes
 - `createClient()`'s middleware wraps `generate()` only; `generateStream()` gets
   the client's retry/timeout/validator defaults but not middleware interception

--- a/README.md
+++ b/README.md
@@ -280,6 +280,124 @@ for await (const event of stream2.events) {
 
 **Streaming smoothness tracks guarantee level.** `native`/`constrained` backends (OpenAI, Groq, Ollama) rarely fail validation — the server already constrains tokens as they're generated — so streams almost never restart. `best-effort` (Anthropic) has no such constraint, so a stream may visibly restart more often.
 
+## createClient() & Middleware
+
+For cross-cutting concerns (logging, caching, telemetry) that would otherwise mean editing `generate()` itself, wrap it once with `createClient()` — a Koa-style onion middleware chain plus client-level defaults.
+
+```typescript
+import { createClient, loggingMiddleware } from "@aviasole/shapecraft";
+
+const client = createClient({
+  middleware: [loggingMiddleware()],
+  retry: { max: 3 },
+  timeoutMs: 10_000,
+});
+
+const result = await client.generate(model, schema, prompt);
+```
+
+A middleware sees the request before `next()` runs and the result/error after — outer middlewares wrap inner ones, like nested boxes, not a flat sequence:
+
+```typescript
+import type { Middleware } from "@aviasole/shapecraft";
+
+const timing: Middleware = async (ctx, next) => {
+  const t0 = Date.now();
+  const result = await next();          // everything below this middleware runs first
+  console.log(`${ctx.model.id} took ${Date.now() - t0}ms`);
+  return result;
+};
+```
+
+A middleware that never calls `next()` short-circuits the real call entirely — the standard shape for a cache:
+
+```typescript
+import type { Middleware, GenerateResult } from "@aviasole/shapecraft";
+
+const cache = new Map<string, GenerateResult<unknown>>();
+
+const cachingMiddleware: Middleware = async (ctx, next) => {
+  const key = `${ctx.model.id}:${ctx.prompt}`;
+  const hit = cache.get(key);
+  if (hit) return hit;                  // model never called
+  const result = await next();
+  cache.set(key, result);
+  return result;
+};
+```
+
+`createClient()` is purely additive — existing direct calls to `generate()`/`generateStream()` are unaffected. Middleware wraps `generate()` only; `generateStream()` picks up the client's `retry`/`timeoutMs`/`jsonSchemaValidator` defaults but isn't intercepted by middleware (its async-iterable shape doesn't fit the simple before/after `next()` model).
+
+## Result Metadata
+
+Every `GenerateResult` includes `metadata`:
+
+```typescript
+const result = await generate(model, schema, prompt);
+
+console.log(result.metadata);
+// { provider: "groq", model: "llama-3.3-70b-versatile", latencyMs: 284 }
+```
+
+```typescript
+interface ResultMetadata {
+  provider: string;
+  model: string;
+  latencyMs: number;
+  tokens?: { input: number; output: number };
+  finishReason?: string;
+  requestId?: string;
+  cost?: number;
+}
+```
+
+`provider`, `model`, and `latencyMs` are always populated by the core (parsed from `model.id`, measured around the call). `tokens`, `finishReason`, `requestId`, and `cost` are reserved for a future backend hook that surfaces the underlying API response's usage data — they're `undefined` today, on every backend.
+
+## Timeouts & Cancellation
+
+Bound or cancel a single attempt with `timeoutMs` and/or an `AbortSignal`:
+
+```typescript
+import { TimeoutError } from "@aviasole/shapecraft";
+
+try {
+  const result = await generate(model, schema, prompt, { timeoutMs: 5_000 });
+} catch (err) {
+  if (err instanceof TimeoutError) {
+    console.error(`Timed out after ${err.timeoutMs}ms`);
+  }
+}
+```
+
+```typescript
+const controller = new AbortController();
+setTimeout(() => controller.abort(), 5_000);
+
+const result = await generate(model, schema, prompt, { signal: controller.signal });
+```
+
+Enforced at the core level for every backend — the retry loop always stops waiting once the timeout/signal fires, even against a backend that ignores cancellation entirely. All four built-in backends (`openai`, `groq`, `anthropic`, `ollama`) additionally forward the signal to the underlying SDK/fetch call for real request cancellation, not just abandonment. `TimeoutError` is never retried (it isn't a `SchemaViolationError`).
+
+## Pluggable JSON Schema Validation
+
+The built-in `jsonSchema` check (`checkJsonSchema`) is intentionally shallow — it validates types and `required` presence, not `minLength`/`maximum`/`pattern`/`$ref`/etc. Rather than expanding it, it's pluggable: supply your own validator (or wire up AJV) via `jsonSchemaValidator`.
+
+```typescript
+const strictValidator = (value: unknown, schema: Record<string, unknown>) => {
+  // throw to reject; return normally to accept
+  const v = value as { age?: number };
+  if (typeof v.age !== "number" || v.age < 0 || v.age > 130) {
+    throw new Error("age must be a plausible human age");
+  }
+};
+
+const result = await generate(model, { jsonSchema: PersonJsonSchema }, prompt, {
+  jsonSchemaValidator: strictValidator,
+});
+```
+
+Applies to both `generate()`'s final check and `generateStream()`'s per-field incremental (`partial`) validation, so a custom validator behaves consistently whether or not you're streaming. Omit it and you get today's `checkJsonSchema` behavior, unchanged.
+
 ## What shapecraft guarantees — and what it doesn't
 
 Every mechanism above (`native`, `constrained`, `best-effort` + retry) targets one thing: **the output is structurally valid** — it parses, the types match, required fields are present and non-empty. That's a real, load-bearing guarantee: it's the difference between code that can trust `result.data.age` is a `number` versus code that has to defensively re-check everything the model says.
@@ -302,6 +420,15 @@ const result = await generate(model, schema, prompt, {
   systemPrompt: "You are a data extraction assistant.",
 });
 ```
+
+| Option | Purpose |
+|---|---|
+| `maxRetries` | attempts before throwing `MaxRetriesExceededError` (default: 2) |
+| `temperature` | forwarded to the backend, where supported |
+| `systemPrompt` | prepended instruction, combined with the schema-derived prompt |
+| `timeoutMs` | bound a single attempt's wall-clock time — see [Timeouts & Cancellation](#timeouts--cancellation) |
+| `signal` | an `AbortSignal` to cancel an in-flight attempt — see [Timeouts & Cancellation](#timeouts--cancellation) |
+| `jsonSchemaValidator` | override the built-in `jsonSchema` structural check — see [Pluggable JSON Schema Validation](#pluggable-json-schema-validation) |
 
 ## Error Handling
 

--- a/examples/client.ts
+++ b/examples/client.ts
@@ -1,0 +1,70 @@
+/**
+ * Example: createClient() — middleware pipeline over generate()/generateStream().
+ *
+ * createClient() is purely additive sugar: it wraps the same generate()/
+ * generateStream() you'd otherwise call directly, adding a Koa-style onion
+ * middleware chain plus client-level defaults (retry/timeout/validator).
+ * Existing direct calls to generate()/generateStream() are unaffected.
+ */
+import { createClient, loggingMiddleware, groq } from "@aviasole/shapecraft";
+import type { GenerateResult, Middleware } from "@aviasole/shapecraft";
+
+const model = groq({ model: "llama-3.3-70b-versatile" });
+
+const schema = {
+  jsonSchema: {
+    type: "object",
+    required: ["name", "age"],
+    properties: { name: { type: "string" }, age: { type: "number" } },
+  },
+};
+
+// ── Simple: built-in loggingMiddleware + client-level defaults ──────────────
+const client = createClient({
+  middleware: [loggingMiddleware()],
+  retry: { max: 3 },
+  timeoutMs: 10_000,
+});
+
+const result = await client.generate(model, schema, "Extract: Jane Doe, 28");
+console.log(result.data, result.metadata);
+// { name: "Jane Doe", age: 28 }  { provider: "groq", model: "llama-3.3-70b-versatile", latencyMs: 284 }
+
+// ── Middleware ordering: outer middleware sees the request first and the
+// result/error last — the same "onion" model as Koa/Express. ────────────────
+const timing =
+  (label: string): Middleware =>
+  async (ctx, next) => {
+    const t0 = Date.now();
+    console.log(`${label} → ${ctx.model.id}`);
+    const res = await next();
+    console.log(`${label} ← done in ${Date.now() - t0}ms`);
+    return res;
+  };
+
+const nested = createClient({ middleware: [timing("outer"), timing("inner")] });
+await nested.generate(model, schema, "Extract: John Smith, 41");
+// outer → groq:llama-3.3-70b-versatile
+// inner → groq:llama-3.3-70b-versatile
+// inner ← done in 284ms
+// outer ← done in 284ms
+
+// ── A middleware that never calls next() short-circuits the real call —
+// the classic shape for a cache layer. ───────────────────────────────────────
+const cache = new Map<string, GenerateResult<unknown>>();
+
+const cachingMiddleware: Middleware = async (ctx, next) => {
+  const key = `${ctx.model.id}:${ctx.prompt}`;
+  const hit = cache.get(key);
+  if (hit) {
+    console.log("cache hit — skipping the real call entirely");
+    return hit;
+  }
+  const result = await next();
+  cache.set(key, result);
+  return result;
+};
+
+const cachedClient = createClient({ middleware: [cachingMiddleware] });
+await cachedClient.generate(model, schema, "Extract: Jane Doe, 28"); // real call, populates cache
+await cachedClient.generate(model, schema, "Extract: Jane Doe, 28"); // cache hit, model never called

--- a/examples/json-schema-validator.ts
+++ b/examples/json-schema-validator.ts
@@ -1,0 +1,70 @@
+/**
+ * Example: jsonSchemaValidator — pluggable structural validation.
+ *
+ * The built-in `jsonSchema` check (checkJsonSchema) is intentionally shallow:
+ * it validates types and `required` presence, not minLength/maximum/pattern/
+ * $ref/etc. Rather than expanding it, it's pluggable — supply your own
+ * validator (or wire up AJV) instead of the default.
+ */
+import { generate, groq } from "@aviasole/shapecraft";
+
+const model = groq({ model: "llama-3.3-70b-versatile" });
+
+const PersonJsonSchema = {
+  type: "object",
+  required: ["name", "age"],
+  properties: { name: { type: "string" }, age: { type: "number" } },
+};
+
+// ── Default behavior: only types + required are checked ─────────────────────
+const loose = await generate(model, { jsonSchema: PersonJsonSchema }, "Extract: Jo, 200");
+console.log(loose.data); // { name: "Jo", age: 200 } — accepted; nothing in the schema forbids this
+
+// ── A stricter validator: throw to reject, return normally to accept ────────
+//
+// Like the built-in checkJsonSchema, this gets called at TWO different
+// scopes, and must handle both: once with the whole object (generate()'s
+// final check), and once per top-level field with just that field's own raw
+// value (generateStream()'s incremental "partial" check, in incremental.ts).
+// A validator that assumes "value is always the whole object" will wrongly
+// reject valid streamed fields, since e.g. the "name" field arrives here as
+// value = "Jane Doe" (a bare string), not { name: "Jane Doe", ... }.
+function strictValidator(value: unknown, schema: Record<string, unknown>): void {
+  if (typeof value === "string" && schema.type === "string" && value.length < 3) {
+    throw new Error("name must be a string of at least 3 characters");
+  }
+  if (typeof value === "number" && schema.type === "number" && (value < 0 || value > 130)) {
+    throw new Error("age must be a plausible human age (0-130)");
+  }
+  if (typeof value === "object" && value !== null) {
+    const v = value as { name?: string; age?: number };
+    if (typeof v.name === "string" && v.name.length < 3) {
+      throw new Error("name must be a string of at least 3 characters");
+    }
+    if (typeof v.age === "number" && (v.age < 0 || v.age > 130)) {
+      throw new Error("age must be a plausible human age (0-130)");
+    }
+  }
+}
+
+try {
+  await generate(model, { jsonSchema: PersonJsonSchema }, "Extract: Jo, 200", {
+    jsonSchemaValidator: strictValidator,
+    maxRetries: 2,
+  });
+} catch {
+  console.log("rejected: name/age fail the stricter rules on every retry");
+}
+
+// ── Applies to generateStream()'s per-field `partial` validation too ────────
+import { generateStream } from "@aviasole/shapecraft";
+
+const stream = generateStream(model, { jsonSchema: PersonJsonSchema }, "Extract: Jane Doe, 28", {
+  jsonSchemaValidator: strictValidator,
+});
+
+for await (const event of stream.events) {
+  if (event.type === "partial") console.log("field validated against strictValidator:", event.value);
+}
+
+console.log((await stream.result).data); // { name: "Jane Doe", age: 28 }

--- a/examples/timeout-abort.ts
+++ b/examples/timeout-abort.ts
@@ -1,0 +1,56 @@
+/**
+ * Example: timeoutMs / signal — bounding and cancelling a single attempt.
+ *
+ * Enforced at the core level for every backend: the retry loop always stops
+ * waiting once the timeout/signal fires, even against a backend that ignores
+ * cancellation entirely. All four built-in backends additionally forward the
+ * signal to the underlying SDK/fetch call for real request cancellation, not
+ * just abandonment.
+ */
+import { generate, groq, TimeoutError } from "@aviasole/shapecraft";
+
+const model = groq({ model: "llama-3.3-70b-versatile" });
+
+const schema = {
+  jsonSchema: {
+    type: "object",
+    required: ["name", "age"],
+    properties: { name: { type: "string" }, age: { type: "number" } },
+  },
+};
+
+// ── timeoutMs: bound a single attempt's wall-clock time ──────────────────────
+try {
+  const result = await generate(model, schema, "Extract: Jane Doe, 28", { timeoutMs: 5_000 });
+  console.log(result.data);
+} catch (err) {
+  if (err instanceof TimeoutError) {
+    console.error(`Timed out after ${err.timeoutMs}ms`);
+  } else {
+    throw err;
+  }
+}
+
+// ── signal: cancel an in-flight attempt from the outside ────────────────────
+const controller = new AbortController();
+const timer = setTimeout(() => controller.abort(new Error("user navigated away")), 5_000);
+
+try {
+  const result = await generate(model, schema, "Extract: John Smith, 41", { signal: controller.signal });
+  clearTimeout(timer);
+  console.log(result.data);
+} catch (err) {
+  clearTimeout(timer);
+  if (err instanceof Error && err.name === "AbortError") {
+    console.error("Cancelled:", err.message);
+  } else {
+    throw err;
+  }
+}
+
+// ── timeoutMs and signal can be combined — whichever fires first wins ───────
+const result = await generate(model, schema, "Extract: Ada Lovelace, 36", {
+  timeoutMs: 10_000,
+  signal: controller.signal,
+});
+console.log(result.data);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "2.0.1",
+      "version": "2.0.2",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
 
@@ -24,16 +24,19 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
     id: `anthropic:${modelId}`,
     guaranteeLevel: "best-effort",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const anthropicClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const response = await anthropicClient.messages.create({
-        model: modelId,
-        max_tokens: 4096,
-        system,
-        messages: [{ role: "user", content: user }],
-      });
+      const response = await anthropicClient.messages.create(
+        {
+          model: modelId,
+          max_tokens: 4096,
+          system,
+          messages: [{ role: "user", content: user }],
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
 
       const raw: string =
         response.content[0]?.type === "text" ? response.content[0].text : "";
@@ -54,16 +57,24 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
       return response.content[0]?.type === "text" ? response.content[0].text : "";
     },
 
-    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
       const anthropicClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const stream = anthropicClient.messages.stream({
-        model: modelId,
-        max_tokens: 4096,
-        system,
-        messages: [{ role: "user", content: user }],
-      });
+      const stream = anthropicClient.messages.stream(
+        {
+          model: modelId,
+          max_tokens: 4096,
+          system,
+          messages: [{ role: "user", content: user }],
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       for await (const event of stream as AsyncIterable<any>) {

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -1,4 +1,4 @@
-import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
 import { isXmlInput } from "../core/validate.js";
@@ -25,19 +25,22 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
     id: `groq:${modelId}`,
     guaranteeLevel: "native",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const groqClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const response = await groqClient.chat.completions.create({
-        model: modelId,
-        messages: [
-          { role: "system", content: system },
-          { role: "user", content: user },
-        ],
-        // XML schemas must not use json_object mode — Groq rejects it when prompt lacks "json"
-        ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
-      });
+      const response = await groqClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          // XML schemas must not use json_object mode — Groq rejects it when prompt lacks "json"
+          ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
 
       const raw: string = response.choices[0]?.message?.content ?? "";
 
@@ -58,19 +61,27 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
       return response.choices[0]?.message?.content ?? "";
     },
 
-    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
       const groqClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const stream = await groqClient.chat.completions.create({
-        model: modelId,
-        messages: [
-          { role: "system", content: system },
-          { role: "user", content: user },
-        ],
-        ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
-        stream: true,
-      });
+      const stream = await groqClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
+          stream: true,
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       for await (const chunk of stream as AsyncIterable<any>) {

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
+import { combineSignals } from "../core/timeout.js";
 
 export interface OllamaBackendOptions {
   model: string;
@@ -31,12 +32,12 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
     id: `ollama:${options.model}`,
     guaranteeLevel: "constrained",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
       const format = formatFor(schema);
 
       const response = await fetch(`${host}/api/chat`, {
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: combineSignals(AbortSignal.timeout(timeoutMs), callOptions?.signal) ?? null,
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
@@ -83,12 +84,17 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
       return json.message?.content ?? "";
     },
 
-    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
       const format = formatFor(schema);
 
       const response = await fetch(`${host}/api/chat`, {
-        signal: AbortSignal.timeout(timeoutMs),
+        signal: combineSignals(AbortSignal.timeout(timeoutMs), callOptions?.signal) ?? null,
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
@@ -44,18 +44,21 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
     id: `openai:${modelId}`,
     guaranteeLevel: "native",
 
-    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const openaiClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const response = await openaiClient.chat.completions.create({
-        model: modelId,
-        messages: [
-          { role: "system", content: system },
-          { role: "user", content: user },
-        ],
-        response_format: responseFormatFor(schema),
-      });
+      const response = await openaiClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
 
       const raw: string = response.choices[0]?.message?.content ?? "";
 
@@ -76,19 +79,27 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
       return response.choices[0]?.message?.content ?? "";
     },
 
-    async *generateStream<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string> {
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
       const openaiClient = await client();
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
 
-      const stream = await openaiClient.chat.completions.create({
-        model: modelId,
-        messages: [
-          { role: "system", content: system },
-          { role: "user", content: user },
-        ],
-        response_format: responseFormatFor(schema),
-        stream: true,
-      });
+      const stream = await openaiClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+          stream: true,
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       for await (const chunk of stream as AsyncIterable<any>) {

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,0 +1,71 @@
+import type { GenerateOptions, GenerateResult, JsonSchemaValidator, SchemaInput, ShapecraftModel, StreamHandle } from "../types.js";
+import { generate } from "./generate.js";
+import { generateStream } from "./stream.js";
+import { composeMiddleware } from "./middleware.js";
+import type { Middleware, MiddlewareContext } from "./middleware.js";
+
+export interface CreateClientOptions {
+  /** Applied in array order — middleware[0] is outermost (sees the request first, the result/error last). */
+  middleware?: Middleware[];
+  /** Default retry ceiling for every call through this client; a per-call `options.maxRetries` still overrides it. */
+  retry?: { max?: number };
+  /** Default per-call timeout; a per-call `options.timeoutMs` still overrides it. */
+  timeoutMs?: number;
+  /** Default pluggable JSON Schema validator (see `GenerateOptions.jsonSchemaValidator`) for every call through this client. */
+  jsonSchemaValidator?: JsonSchemaValidator;
+}
+
+export interface ShapecraftClient {
+  generate<T>(model: ShapecraftModel, schema: SchemaInput<T>, prompt: string, options?: GenerateOptions): Promise<GenerateResult<T>>;
+  generateStream<T>(model: ShapecraftModel, schema: SchemaInput<T>, prompt: string, options?: GenerateOptions): StreamHandle<T>;
+}
+
+/**
+ * Wraps generate()/generateStream() with a middleware pipeline and client-level
+ * defaults (retry/timeout/validator) — purely additive sugar. Existing direct
+ * calls to generate()/generateStream() are completely unaffected by this
+ * existing; it's a new, optional entry point, not a replacement.
+ *
+ * Middleware wraps `generate()` only. `generateStream()` is not threaded
+ * through the pipeline — its async-iterable shape doesn't fit the simple
+ * before/after `next()` model cleanly (see the streaming-parser-refactor
+ * item in PLAN-Updated.md). It still receives the client's retry/timeout/
+ * validator defaults, just not middleware interception.
+ *
+ * `turnaround` calls are out of scope for this wrapper in v1 — use the
+ * top-level `generate(model, schema, prompt, options, { turnaround: true })`
+ * directly for multi-turn conversations.
+ */
+export function createClient(clientOptions: CreateClientOptions = {}): ShapecraftClient {
+  const chain = composeMiddleware(clientOptions.middleware ?? []);
+
+  function mergeOptions(options: GenerateOptions): GenerateOptions {
+    return {
+      ...(clientOptions.retry?.max !== undefined ? { maxRetries: clientOptions.retry.max } : {}),
+      ...(clientOptions.timeoutMs !== undefined ? { timeoutMs: clientOptions.timeoutMs } : {}),
+      ...(clientOptions.jsonSchemaValidator !== undefined ? { jsonSchemaValidator: clientOptions.jsonSchemaValidator } : {}),
+      ...options, // per-call options always win over client-level defaults
+    };
+  }
+
+  return {
+    generate<T>(
+      model: ShapecraftModel,
+      schema: SchemaInput<T>,
+      prompt: string,
+      options: GenerateOptions = {}
+    ): Promise<GenerateResult<T>> {
+      const ctx: MiddlewareContext<T> = { model, schema, prompt, options: mergeOptions(options) };
+      return chain(ctx, () => generate<T>(ctx.model, ctx.schema, ctx.prompt, ctx.options));
+    },
+
+    generateStream<T>(
+      model: ShapecraftModel,
+      schema: SchemaInput<T>,
+      prompt: string,
+      options: GenerateOptions = {}
+    ): StreamHandle<T> {
+      return generateStream<T>(model, schema, prompt, mergeOptions(options));
+    },
+  };
+}

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -1,6 +1,7 @@
 import type {
   GenerateOptions,
   GenerateResult,
+  ResultMetadata,
   SchemaInput,
   ShapecraftModel,
   TurnaroundOptions,
@@ -9,6 +10,12 @@ import type {
 import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
 import { validateOutput } from "./validate.js";
 import { runTurnaround } from "./turnaround.js";
+import { createTimeoutGuard } from "./timeout.js";
+
+export function parseProviderModel(id: string): { provider: string; model: string } {
+  const idx = id.indexOf(":");
+  return idx === -1 ? { provider: id, model: id } : { provider: id.slice(0, idx), model: id.slice(idx + 1) };
+}
 
 export function generate<T>(
   model: ShapecraftModel,
@@ -35,20 +42,34 @@ export async function generate<T>(
   }
 
   const maxRetries = options.maxRetries ?? 3;
-  const { systemPrompt } = options;
+  const { systemPrompt, timeoutMs, signal, jsonSchemaValidator } = options;
+  const { provider, model: modelName } = parseProviderModel(model.id);
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
+    // Fail fast on an already-aborted signal — skip calling the backend
+    // entirely rather than invoking it just to have Promise.race discard it.
+    if (signal?.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+
+    const t0 = Date.now();
+    const { guard, signal: callSignal, cleanup } = createTimeoutGuard(timeoutMs, signal);
     try {
-      const raw = await model.generate<T>(prompt, schema, systemPrompt);
-      const data = validateOutput<T>(raw, schema);
+      const raw = await Promise.race([
+        model.generate<T>(prompt, schema, systemPrompt, callSignal ? { signal: callSignal } : undefined),
+        guard,
+      ]);
+      const data = validateOutput<T>(raw, schema, { jsonSchemaValidator });
+      const metadata: ResultMetadata = { provider, model: modelName, latencyMs: Date.now() - t0 };
       return {
         data,
         guaranteeLevel: model.guaranteeLevel,
         attempts: attempt,
+        metadata,
       };
     } catch (err) {
       if (!(err instanceof SchemaViolationError)) throw err;
       if (attempt === maxRetries) break;
+    } finally {
+      cleanup();
     }
   }
 

--- a/src/core/incremental.ts
+++ b/src/core/incremental.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { SchemaInput } from "../types.js";
+import type { JsonSchemaValidator, SchemaInput } from "../types.js";
 import { checkJsonSchema, isXmlInput } from "./validate.js";
 
 /**
@@ -151,7 +151,12 @@ export function extractCompletedTopLevelFields(buffer: string): Record<string, s
  * passed (or there's no sub-schema for it / for this schema type at all —
  * XML, pattern, and custom-validator schemas never decompose).
  */
-export function validateFieldIfPossible<T>(schema: SchemaInput<T>, key: string, value: unknown): string | null {
+export function validateFieldIfPossible<T>(
+  schema: SchemaInput<T>,
+  key: string,
+  value: unknown,
+  opts: { jsonSchemaValidator?: JsonSchemaValidator | undefined } = {}
+): string | null {
   if (isXmlInput(schema)) return null;
 
   if (schema instanceof z.ZodType) {
@@ -170,7 +175,8 @@ export function validateFieldIfPossible<T>(schema: SchemaInput<T>, key: string, 
     const propSchema = properties?.[key];
     if (!propSchema) return null;
     try {
-      checkJsonSchema(value, propSchema);
+      const validate = opts.jsonSchemaValidator ?? checkJsonSchema;
+      validate(value, propSchema);
       return null;
     } catch (err) {
       return err instanceof Error ? err.message : String(err);

--- a/src/core/incremental.ts
+++ b/src/core/incremental.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { JsonSchemaValidator, SchemaInput } from "../types.js";
-import { checkJsonSchema, isXmlInput } from "./validate.js";
+import { checkJsonSchema, isXmlInput, isZodSchema } from "./validate.js";
 
 /**
  * Scans a growing JSON buffer for top-level object fields whose value has
@@ -159,7 +159,7 @@ export function validateFieldIfPossible<T>(
 ): string | null {
   if (isXmlInput(schema)) return null;
 
-  if (schema instanceof z.ZodType) {
+  if (isZodSchema(schema)) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const shape = (schema as any).shape as Record<string, z.ZodTypeAny> | undefined;
     const fieldSchema = shape?.[key];

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -1,0 +1,67 @@
+import type { GenerateOptions, GenerateResult, SchemaInput, ShapecraftModel } from "../types.js";
+
+/** What a middleware sees for one generate() call. */
+export interface MiddlewareContext<T = unknown> {
+  model: ShapecraftModel;
+  schema: SchemaInput<T>;
+  prompt: string;
+  options: GenerateOptions;
+}
+
+/** Calls the next middleware in the chain (or the real generate() call if this is the last one). */
+export type NextFn<T> = () => Promise<GenerateResult<T>>;
+
+/**
+ * Koa-style onion middleware: wraps a generate() call for logging, caching,
+ * telemetry, etc. Must call `next()` at most once — calling it twice throws,
+ * calling it zero times short-circuits the real call (useful for a cache hit).
+ */
+export interface Middleware {
+  <T>(ctx: MiddlewareContext<T>, next: NextFn<T>): Promise<GenerateResult<T>>;
+}
+
+/**
+ * Composes middlewares into a single callable: `chain(ctx, core)` runs
+ * middleware[0], which calls next() to run middleware[1], ... down to `core`
+ * (the real generate() call). An empty array degenerates to calling `core`
+ * directly.
+ */
+export function composeMiddleware(middlewares: Middleware[]) {
+  return function chain<T>(ctx: MiddlewareContext<T>, core: NextFn<T>): Promise<GenerateResult<T>> {
+    let lastIndexCalled = -1;
+
+    function dispatch(i: number): Promise<GenerateResult<T>> {
+      if (i <= lastIndexCalled) {
+        return Promise.reject(new Error("Middleware called next() more than once"));
+      }
+      lastIndexCalled = i;
+
+      const mw = middlewares[i];
+      if (!mw) return core();
+      return mw(ctx, () => dispatch(i + 1));
+    }
+
+    return dispatch(0);
+  };
+}
+
+/**
+ * Minimal example middleware — logs before/after each call via the given
+ * logger (defaults to console). Handy for wiring up createClient() quickly
+ * and as a template for writing your own (caching, telemetry, retries-with-
+ * backoff, etc. all follow the same next()-wrapping shape).
+ */
+export function loggingMiddleware(logger: Pick<Console, "log" | "error"> = console): Middleware {
+  return async <T>(ctx: MiddlewareContext<T>, next: NextFn<T>): Promise<GenerateResult<T>> => {
+    const label = `[shapecraft] ${ctx.model.id}`;
+    logger.log(`${label} → request`);
+    try {
+      const result = await next();
+      logger.log(`${label} ← done in ${result.metadata.latencyMs}ms (attempts=${result.attempts})`);
+      return result;
+    } catch (err) {
+      logger.error(`${label} ← failed: ${err instanceof Error ? err.message : String(err)}`);
+      throw err;
+    }
+  };
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -2,7 +2,7 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { SchemaInput, ValidatorInput } from "../types.js";
 import { buildXmlSystemPrompt } from "./xml.js";
-import { isXmlInput } from "./validate.js";
+import { isXmlInput, isZodSchema } from "./validate.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toJsonSchema(schema: z.ZodType<any>): Record<string, unknown> {
@@ -17,7 +17,7 @@ export function buildStructuredPrompt(
 ): { system: string; user: string } {
   let schemaInfo: string;
 
-  if (schema instanceof z.ZodType) {
+  if (isZodSchema(schema)) {
     schemaInfo = `Respond with valid JSON matching this schema exactly:\n\n${JSON.stringify(toJsonSchema(schema), null, 2)}`;
   } else if ("jsonSchema" in schema) {
     schemaInfo = `Respond with valid JSON matching this schema exactly:\n\n${JSON.stringify(schema.jsonSchema, null, 2)}`;

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -1,8 +1,9 @@
-import type { GenerateOptions, GenerateResult, SchemaInput, ShapecraftModel, StreamEvent, StreamHandle } from "../types.js";
+import type { GenerateOptions, GenerateResult, ResultMetadata, SchemaInput, ShapecraftModel, StreamEvent, StreamHandle } from "../types.js";
 import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
-import { generate } from "./generate.js";
+import { generate, parseProviderModel } from "./generate.js";
 import { parseAndValidate } from "./parse.js";
 import { extractCompletedTopLevelFields, validateFieldIfPossible } from "./incremental.js";
+import { createTimeoutGuard } from "./timeout.js";
 
 /**
  * Single-consumer async channel. textStream and events are two independent
@@ -59,7 +60,8 @@ export function generateStream<T>(
   options: GenerateOptions = {}
 ): StreamHandle<T> {
   const maxRetries = options.maxRetries ?? 3;
-  const { systemPrompt } = options;
+  const { systemPrompt, timeoutMs, signal, jsonSchemaValidator } = options;
+  const { provider, model: modelName } = parseProviderModel(model.id);
 
   const textChannel = createChannel<string>();
   const eventChannel = createChannel<StreamEvent<T>>();
@@ -96,6 +98,15 @@ export function generateStream<T>(
     }
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
+      // Fail fast on an already-aborted signal — skip calling the backend
+      // entirely rather than invoking it just to have the race discard it.
+      if (signal?.aborted) {
+        finish();
+        rejectResult(signal.reason ?? new DOMException("Aborted", "AbortError"));
+        return;
+      }
+
+      const t0 = Date.now();
       emit({ type: "attempt-start", attempt });
       let buffer = "";
       const validatedKeys = new Set<string>();
@@ -103,8 +114,23 @@ export function generateStream<T>(
       const partialValue: Record<string, unknown> = {};
       let earlyFailure: SchemaViolationError | null = null;
 
+      const { guard, signal: callSignal, cleanup } = createTimeoutGuard(timeoutMs, signal);
+      const iterator = model.generateStream<T>(
+        prompt,
+        schema,
+        systemPrompt,
+        callSignal ? { signal: callSignal } : undefined
+      )[Symbol.asyncIterator]();
+
       try {
-        for await (const delta of model.generateStream<T>(prompt, schema, systemPrompt)) {
+        while (true) {
+          // Race each chunk (not the whole stream) against the shared guard,
+          // so a hung backend that never yields a next chunk still respects
+          // timeoutMs/signal instead of blocking generateStream() forever.
+          const next = await Promise.race([iterator.next(), guard]);
+          if (next.done) break;
+          const delta = next.value;
+
           buffer += delta;
           emit({ type: "delta", text: delta, attempt });
 
@@ -125,7 +151,7 @@ export function generateStream<T>(
               continue; // shouldn't happen — the scanner only returns syntactically closed values
             }
 
-            const fieldError = validateFieldIfPossible(schema, key, value);
+            const fieldError = validateFieldIfPossible(schema, key, value, { jsonSchemaValidator });
             if (fieldError) {
               earlyFailure = new SchemaViolationError(buffer, { field: key, error: fieldError });
               break;
@@ -138,12 +164,16 @@ export function generateStream<T>(
           if (earlyFailure) break; // stop consuming further deltas — no point streaming a doomed attempt
         }
       } catch (err) {
-        // Transport/network error (or a synchronous validation throw, e.g. a bad
-        // XML template) — not a SchemaViolationError, so it is never retried.
+        // Transport/network error, a timeout/abort, or a synchronous validation
+        // throw (e.g. a bad XML template) — not a SchemaViolationError, so it
+        // is never retried.
+        await iterator.return?.().catch(() => {}); // stop the underlying generator cleanly
+        cleanup();
         finish();
         rejectResult(err);
         return;
       }
+      cleanup();
 
       if (earlyFailure) {
         emit({ type: "attempt-failed", attempt, error: earlyFailure });
@@ -160,7 +190,8 @@ export function generateStream<T>(
         // the extraction regex matches the whole string (no-op); for a
         // best-effort backend that wraps JSON in prose, it's required.
         const data = parseAndValidate<T>(buffer, schema, { extractJson: true });
-        const finalResult: GenerateResult<T> = { data, guaranteeLevel: model.guaranteeLevel, attempts: attempt };
+        const metadata: ResultMetadata = { provider, model: modelName, latencyMs: Date.now() - t0 };
+        const finalResult: GenerateResult<T> = { data, guaranteeLevel: model.guaranteeLevel, attempts: attempt, metadata };
         emit({ type: "done", result: finalResult });
         finish();
         resolveResult(finalResult);

--- a/src/core/timeout.ts
+++ b/src/core/timeout.ts
@@ -1,0 +1,79 @@
+import { TimeoutError } from "../types.js";
+
+export interface TimeoutGuard {
+  /** Combined signal to hand to a backend — aborts on timeout OR external abort. `undefined` iff neither was requested, so a backend sees exactly what it saw before this existed. */
+  signal: AbortSignal | undefined;
+  /** Never resolves; rejects with TimeoutError or the external abort reason. Race this against the real work. */
+  guard: Promise<never>;
+  /** Always call once the race settles, win or lose — clears the timer and detaches the abort listener. */
+  cleanup: () => void;
+}
+
+/**
+ * Builds the timeout/abort machinery shared by generate() and generateStream().
+ * When neither `timeoutMs` nor `externalSignal` is set (the common case today),
+ * `signal` is `undefined` and `guard` never settles — racing against it is a
+ * no-op, so existing behavior is byte-for-byte unchanged.
+ */
+export function createTimeoutGuard(timeoutMs: number | undefined, externalSignal: AbortSignal | undefined): TimeoutGuard {
+  if (externalSignal?.aborted) {
+    return {
+      signal: externalSignal,
+      guard: Promise.reject(externalSignal.reason ?? new DOMException("Aborted", "AbortError")),
+      cleanup: () => {},
+    };
+  }
+
+  if (!timeoutMs && !externalSignal) {
+    return { signal: undefined, guard: new Promise<never>(() => {}), cleanup: () => {} };
+  }
+
+  const controller = new AbortController();
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let onExternalAbort: (() => void) | undefined;
+
+  const guard = new Promise<never>((_, reject) => {
+    if (timeoutMs) {
+      timer = setTimeout(() => {
+        controller.abort();
+        reject(new TimeoutError(timeoutMs));
+      }, timeoutMs);
+      // Don't let a pending timer keep the process alive on its own.
+      timer.unref?.();
+    }
+    if (externalSignal) {
+      onExternalAbort = () => {
+        controller.abort();
+        reject(externalSignal.reason ?? new DOMException("Aborted", "AbortError"));
+      };
+      externalSignal.addEventListener("abort", onExternalAbort);
+    }
+  });
+
+  const cleanup = () => {
+    if (timer) clearTimeout(timer);
+    if (onExternalAbort) externalSignal?.removeEventListener("abort", onExternalAbort);
+  };
+
+  return { signal: controller.signal, guard, cleanup };
+}
+
+/** Combines multiple optional AbortSignals into one that aborts when any of
+ * them do. Used by backends that already build their own internal signal
+ * (e.g. ollama's request timeout) and need to also honor a caller-supplied
+ * one. Avoids relying on `AbortSignal.any` for broader Node compatibility. */
+export function combineSignals(...signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const present = signals.filter((s): s is AbortSignal => !!s);
+  if (present.length === 0) return undefined;
+  if (present.length === 1) return present[0];
+
+  const controller = new AbortController();
+  for (const s of present) {
+    if (s.aborted) {
+      controller.abort(s.reason);
+      break;
+    }
+    s.addEventListener("abort", () => controller.abort(s.reason), { once: true });
+  }
+  return controller.signal;
+}

--- a/src/core/turnaround.ts
+++ b/src/core/turnaround.ts
@@ -10,7 +10,7 @@ import type {
 } from "../types.js";
 import { MaxTurnsExceededError } from "../types.js";
 import { generate } from "./generate.js";
-import { isXmlInput } from "./validate.js";
+import { isXmlInput, isZodSchema } from "./validate.js";
 
 /** Emitted alone by the model to signal the conversation has everything it needs. */
 export const COMPLETION_SENTINEL = "<<<COMPLETE>>>";
@@ -26,7 +26,7 @@ export function createConversationMemory(): ConversationMemory {
  * fields (pattern, custom validator without a hint) — the checklist is skipped.
  */
 function requiredFieldNames<T>(schema: SchemaInput<T>): string[] | undefined {
-  if (schema instanceof z.ZodType) {
+  if (isZodSchema(schema)) {
     // Read the shape directly rather than going through toJsonSchema — reliable
     // across zod versions and doesn't depend on zod-to-json-schema's internals.
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { SchemaInput, XmlInput } from "../types.js";
+import type { JsonSchemaValidator, SchemaInput, XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
 import { finalizeXmlOutput } from "./xml.js";
 
@@ -59,7 +59,11 @@ export function checkJsonSchema(value: unknown, schema: Record<string, unknown>)
   }
 }
 
-export function validateOutput<T>(output: unknown, schema: SchemaInput<T>): T {
+export function validateOutput<T>(
+  output: unknown,
+  schema: SchemaInput<T>,
+  opts: { jsonSchemaValidator?: JsonSchemaValidator | undefined } = {}
+): T {
   if (isZodSchema(schema)) {
     const result = schema.safeParse(nullToUndefined(output));
     if (!result.success) throw new SchemaViolationError(JSON.stringify(output), result.error);
@@ -68,7 +72,8 @@ export function validateOutput<T>(output: unknown, schema: SchemaInput<T>): T {
 
   if ("jsonSchema" in schema) {
     try {
-      checkJsonSchema(output, schema.jsonSchema);
+      const validate = opts.jsonSchemaValidator ?? checkJsonSchema;
+      validate(output, schema.jsonSchema);
     } catch (err) {
       throw new SchemaViolationError(JSON.stringify(output), err);
     }

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -3,8 +3,20 @@ import type { JsonSchemaValidator, SchemaInput, XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
 import { finalizeXmlOutput } from "./xml.js";
 
+// Duck-typed rather than `instanceof z.ZodType`: a `file:`-linked or
+// nested-install consumer can end up with a different zod module instance
+// (or major version) than the one this schema was built with, which makes
+// `instanceof` false even for a genuine Zod schema. `_def`/`parse`/`safeParse`
+// are present on every ZodType across zod v3 and v4, and none of the other
+// SchemaInput shapes (jsonSchema/pattern/validate/xml) have all three.
 export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
-  return schema instanceof z.ZodType;
+  return (
+    typeof schema === "object" &&
+    schema !== null &&
+    "_def" in schema &&
+    typeof (schema as { parse?: unknown }).parse === "function" &&
+    typeof (schema as { safeParse?: unknown }).safeParse === "function"
+  );
 }
 
 export function isXmlInput(schema: SchemaInput): schema is XmlInput {

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,14 +3,20 @@ export { generateStream } from "./core/stream.js";
 export { toJsonSchema, buildStructuredPrompt } from "./core/schema.js";
 export { xmlType, validateXmlTemplate } from "./core/xml.js";
 export { createConversationMemory, COMPLETION_SENTINEL } from "./core/turnaround.js";
+export { createClient } from "./core/client.js";
+export { composeMiddleware, loggingMiddleware } from "./core/middleware.js";
+export { checkJsonSchema } from "./core/validate.js";
 
 export * from "./backends/index.js";
 
 export type {
   ShapecraftModel,
+  ModelCallOptions,
   SchemaInput,
   GenerateOptions,
   GenerateResult,
+  ResultMetadata,
+  JsonSchemaValidator,
   GuaranteeLevel,
   XmlInput,
   ChatMessage,
@@ -21,4 +27,7 @@ export type {
   StreamHandle,
 } from "./types.js";
 
-export { SchemaViolationError, MaxRetriesExceededError, MaxTurnsExceededError } from "./types.js";
+export type { CreateClientOptions, ShapecraftClient } from "./core/client.js";
+export type { Middleware, MiddlewareContext, NextFn } from "./core/middleware.js";
+
+export { SchemaViolationError, MaxRetriesExceededError, MaxTurnsExceededError, TimeoutError } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,10 +36,23 @@ export interface ChatMessage {
   content: string;
 }
 
+/**
+ * Extra per-call knobs a backend MAY read. Passed as an additional, optional
+ * argument — a backend that doesn't declare this parameter at all still
+ * satisfies `ShapecraftModel` (TypeScript allows implementing fewer params
+ * than an interface declares) and behaves exactly as it did before this
+ * existed. Backends that DO read `signal` get real request cancellation;
+ * everything else still gets the core-level timeout/abort guarantee (the
+ * retry loop stops waiting) even if the underlying call keeps running.
+ */
+export interface ModelCallOptions {
+  signal?: AbortSignal;
+}
+
 export interface ShapecraftModel {
   id: string;
   guaranteeLevel: GuaranteeLevel;
-  generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T>;
+  generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T>;
   /**
    * Plain, unconstrained conversational turn (no schema/JSON mode imposed).
    * Required for `turnaround: true` — models without it throw when used that way.
@@ -51,19 +64,63 @@ export interface ShapecraftModel {
    * buffer through the same pipeline as non-streaming `generate()`.
    * Absence ⇒ the core falls back to one-shot `generate()`.
    */
-  generateStream?<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): AsyncIterable<string>;
+  generateStream?<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): AsyncIterable<string>;
 }
+
+/**
+ * Pluggable JSON Schema structural validator (used only for `{ jsonSchema }`
+ * inputs). Receives the same `(value, schema)` shape the built-in
+ * `checkJsonSchema` does and must throw on failure. Omit to keep today's
+ * built-in shallow validator — passing this option is the only way its
+ * behavior changes.
+ */
+export type JsonSchemaValidator = (value: unknown, schema: Record<string, unknown>) => void;
 
 export interface GenerateOptions {
   maxRetries?: number;
   systemPrompt?: string;
   temperature?: number;
+  /**
+   * Abort the in-flight call. Always enforced at the core level — the retry
+   * loop stops waiting the instant it fires — regardless of whether the
+   * backend itself reads `signal`. A backend that does gets the underlying
+   * network request actually cancelled, not just abandoned.
+   */
+  signal?: AbortSignal;
+  /**
+   * Milliseconds before a single attempt is abandoned with a `TimeoutError`.
+   * Enforced with the same core-level guarantee as `signal` above: generate()
+   * never waits longer than this for one attempt, even against a backend
+   * that ignores the passed-through signal.
+   */
+  timeoutMs?: number;
+  /**
+   * Override the built-in `{ jsonSchema }` structural check (e.g. swap in
+   * AJV for `oneOf`/`format`/`pattern` support `checkJsonSchema` doesn't
+   * have). Defaults to the bundled shallow validator when omitted — existing
+   * callers see no behavior change.
+   */
+  jsonSchemaValidator?: JsonSchemaValidator;
+}
+
+/** Best-effort call metadata — always present, but only `provider`/`model`/
+ * `latencyMs` are guaranteed populated by the core today; the rest stay
+ * `undefined` until a backend opts in to supplying them. */
+export interface ResultMetadata {
+  provider: string;
+  model: string;
+  latencyMs: number;
+  tokens?: { input: number; output: number };
+  finishReason?: string;
+  requestId?: string;
+  cost?: number;
 }
 
 export interface GenerateResult<T> {
   data: T;
   guaranteeLevel: GuaranteeLevel;
   attempts: number;
+  metadata: ResultMetadata;
 }
 
 export class SchemaViolationError extends Error {
@@ -87,6 +144,19 @@ export class MaxTurnsExceededError extends Error {
   constructor(public readonly turns: number) {
     super(`Conversation did not complete after ${turns} turns`);
     this.name = "MaxTurnsExceededError";
+  }
+}
+
+/**
+ * A single attempt exceeded `timeoutMs`, or was cancelled via `signal`. NOT a
+ * SchemaViolationError, so generate()'s retry loop does not swallow it — it
+ * propagates to the caller immediately instead of silently retrying, since a
+ * hung/slow backend retrying just as slowly rarely self-heals.
+ */
+export class TimeoutError extends Error {
+  constructor(public readonly timeoutMs: number) {
+    super(`Generation timed out after ${timeoutMs}ms`);
+    this.name = "TimeoutError";
   }
 }
 

--- a/tests/hardening.test.ts
+++ b/tests/hardening.test.ts
@@ -1,0 +1,348 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import { generate } from "../src/core/generate.js";
+import { generateStream } from "../src/core/stream.js";
+import { createClient } from "../src/core/client.js";
+import { composeMiddleware, loggingMiddleware } from "../src/core/middleware.js";
+import type { Middleware, MiddlewareContext, NextFn } from "../src/core/middleware.js";
+import { MaxRetriesExceededError, SchemaViolationError, TimeoutError } from "../src/types.js";
+import type { GenerateResult, ModelCallOptions, SchemaInput, ShapecraftModel } from "../src/types.js";
+import { mockModel } from "./helpers/index.js";
+
+// ─── Mocks ─────────────────────────────────────────────────────────────────────
+
+/** Resolves after `ms`. If `wellBehaved`, actually cancels its own timer on
+ * abort (like a real fetch/SDK call would) and records whether it was
+ * cancelled — lets tests prove `signal` really reaches the backend, not just
+ * that the core stops waiting. */
+function delayedMockModel(ms: number, returnValue: unknown, opts: { wellBehaved?: boolean; onAbort?: () => void } = {}): ShapecraftModel {
+  return {
+    id: "mockprovider:mockmodel",
+    guaranteeLevel: "constrained",
+    async generate<T>(_p: string, _s: SchemaInput<T>, _sys?: string, callOptions?: ModelCallOptions): Promise<T> {
+      return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(() => resolve(returnValue as T), ms);
+        if (opts.wellBehaved && callOptions?.signal) {
+          callOptions.signal.addEventListener("abort", () => {
+            clearTimeout(timer);
+            opts.onAbort?.();
+            reject(callOptions.signal!.reason ?? new DOMException("Aborted", "AbortError"));
+          });
+        }
+      });
+    },
+  };
+}
+
+function streamingMockModel(chunks: string[], perChunkMs = 0): ShapecraftModel {
+  return {
+    id: "mockprovider:streammodel",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      throw new Error("generate() should not be called in streaming tests");
+    },
+    async *generateStream<T>(): AsyncIterable<string> {
+      for (const c of chunks) {
+        if (perChunkMs) await new Promise((r) => setTimeout(r, perChunkMs));
+        yield c;
+      }
+    },
+  } as ShapecraftModel;
+}
+
+// ─── 7.1 createClient() + middleware ───────────────────────────────────────────
+
+describe("createClient + middleware", () => {
+  it("wraps generate() and returns the same result shape as calling generate() directly", async () => {
+    const client = createClient();
+    const model = mockModel({ name: "Alice", age: 30 });
+    const result = await client.generate(model, z.object({ name: z.string(), age: z.number() }), "get person");
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+    expect(result.metadata.provider).toBe("mock");
+  });
+
+  it("runs middleware in onion order (outer before/after wraps inner before/after)", async () => {
+    const order: string[] = [];
+    const tag =
+      (name: string): Middleware =>
+      async (ctx, next) => {
+        order.push(`${name}:before`);
+        const result = await next();
+        order.push(`${name}:after`);
+        return result;
+      };
+
+    const client = createClient({ middleware: [tag("outer"), tag("inner")] });
+    await client.generate(mockModel({ ok: true }), { validate: () => true }, "x");
+
+    expect(order).toEqual(["outer:before", "inner:before", "inner:after", "outer:after"]);
+  });
+
+  it("a middleware that never calls next() short-circuits — the real generate() never runs", async () => {
+    let coreCalled = false;
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        coreCalled = true;
+        return {} as T;
+      },
+    };
+    const cached: GenerateResult<unknown> = {
+      data: { cached: true },
+      guaranteeLevel: "constrained",
+      attempts: 0,
+      metadata: { provider: "cache", model: "n/a", latencyMs: 0 },
+    };
+    const shortCircuit: Middleware = async () => cached;
+
+    const client = createClient({ middleware: [shortCircuit] });
+    const result = await client.generate(model, { validate: () => true }, "x");
+
+    expect(result).toBe(cached);
+    expect(coreCalled).toBe(false);
+  });
+
+  it("calling next() twice rejects with a clear error", async () => {
+    const doubleNext: Middleware = async (_ctx, next) => {
+      await next();
+      return next(); // second call — must reject
+    };
+    const client = createClient({ middleware: [doubleNext] });
+    await expect(client.generate(mockModel({ ok: true }), { validate: () => true }, "x")).rejects.toThrow(/next\(\) more than once/);
+  });
+
+  it("propagates an error thrown by a middleware after next() resolves", async () => {
+    const throwsAfter: Middleware = async (_ctx, next) => {
+      await next();
+      throw new Error("post-processing failed");
+    };
+    const client = createClient({ middleware: [throwsAfter] });
+    await expect(client.generate(mockModel({ ok: true }), { validate: () => true }, "x")).rejects.toThrow("post-processing failed");
+  });
+
+  it("client-level retry/timeout defaults apply, and a per-call option overrides them", async () => {
+    let calls = 0;
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        calls++;
+        throw new SchemaViolationError("bad", "invalid");
+      },
+    };
+    const client = createClient({ retry: { max: 2 } });
+    await expect(client.generate(model, { validate: () => true }, "x")).rejects.toBeInstanceOf(MaxRetriesExceededError);
+    expect(calls).toBe(2); // client default honored
+
+    calls = 0;
+    await expect(client.generate(model, { validate: () => true }, "x", { maxRetries: 5 })).rejects.toBeInstanceOf(MaxRetriesExceededError);
+    expect(calls).toBe(5); // per-call override wins
+  });
+
+  it("loggingMiddleware logs a request/done pair through a custom logger without throwing", async () => {
+    const logs: string[] = [];
+    const logger = { log: (m: string) => logs.push(m), error: (m: string) => logs.push(`ERR:${m}`) };
+    const client = createClient({ middleware: [loggingMiddleware(logger)] });
+    await client.generate(mockModel({ ok: true }), { validate: () => true }, "x");
+    expect(logs.some((l) => l.includes("request"))).toBe(true);
+    expect(logs.some((l) => l.includes("done"))).toBe(true);
+  });
+
+  it("stress: 100 chained middlewares still preserve order and complete", async () => {
+    const order: number[] = [];
+    const middlewares: Middleware[] = Array.from({ length: 100 }, (_, i) => async (_ctx, next) => {
+      order.push(i);
+      const r = await next();
+      order.push(-i);
+      return r;
+    });
+    const chain = composeMiddleware(middlewares);
+    const ctx: MiddlewareContext<unknown> = { model: mockModel({ ok: true }), schema: { validate: () => true }, prompt: "x", options: {} };
+    const core: NextFn<unknown> = async () => ({
+      data: { ok: true },
+      guaranteeLevel: "constrained",
+      attempts: 1,
+      metadata: { provider: "mock", model: "test", latencyMs: 0 },
+    });
+    const result = await chain(ctx, core);
+    expect(result.data).toEqual({ ok: true });
+    expect(order.slice(0, 100)).toEqual(Array.from({ length: 100 }, (_, i) => i));
+    expect(order.slice(100)).toEqual(Array.from({ length: 100 }, (_, i) => -(99 - i)));
+  });
+});
+
+// ─── 7.2 Metadata ───────────────────────────────────────────────────────────────
+
+describe("GenerateResult.metadata", () => {
+  it("parses provider/model from a `provider:model` id and measures latency", async () => {
+    const model = delayedMockModel(20, { ok: true });
+    const result = await generate(model, { validate: () => true }, "x");
+    expect(result.metadata.provider).toBe("mockprovider");
+    expect(result.metadata.model).toBe("mockmodel");
+    expect(result.metadata.latencyMs).toBeGreaterThanOrEqual(15);
+  });
+
+  it("falls back to the whole id for provider AND model when there's no colon", async () => {
+    const model: ShapecraftModel = { id: "solo", guaranteeLevel: "constrained", async generate<T>(): Promise<T> { return {} as T; } };
+    const result = await generate(model, { validate: () => true }, "x");
+    expect(result.metadata.provider).toBe("solo");
+    expect(result.metadata.model).toBe("solo");
+  });
+
+  it("is present on generateStream()'s final result too", async () => {
+    const model = streamingMockModel(['{"a":1}']);
+    const stream = generateStream(model, { jsonSchema: { type: "object", properties: { a: { type: "number" } } } }, "x");
+    const result = await stream.result;
+    expect(result.metadata.provider).toBe("mockprovider");
+    expect(typeof result.metadata.latencyMs).toBe("number");
+  });
+
+  it("existing consumers destructuring only {data, attempts, guaranteeLevel} are unaffected by the new field", async () => {
+    const model = mockModel({ name: "Alice", age: 30 });
+    const { data, attempts, guaranteeLevel } = await generate(model, z.object({ name: z.string(), age: z.number() }), "x");
+    expect(data).toEqual({ name: "Alice", age: 30 });
+    expect(attempts).toBe(1);
+    expect(guaranteeLevel).toBe("constrained");
+  });
+});
+
+// ─── 7.3 AbortSignal + timeout ──────────────────────────────────────────────────
+
+describe("timeoutMs / signal — generate()", () => {
+  it("no timeoutMs/signal: behavior is byte-for-byte unchanged (regression)", async () => {
+    const model = mockModel({ name: "Alice", age: 30 });
+    const result = await generate(model, z.object({ name: z.string(), age: z.number() }), "x");
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+    expect(result.attempts).toBe(1);
+  });
+
+  it("throws TimeoutError when the attempt exceeds timeoutMs", async () => {
+    const model = delayedMockModel(200, { ok: true });
+    await expect(generate(model, { validate: () => true }, "x", { timeoutMs: 30, maxRetries: 1 })).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it("core-level timeout still bounds wait time even against a backend that ignores signal", async () => {
+    const model = delayedMockModel(500, { ok: true }, { wellBehaved: false });
+    const t0 = Date.now();
+    await expect(generate(model, { validate: () => true }, "x", { timeoutMs: 40, maxRetries: 1 })).rejects.toBeInstanceOf(TimeoutError);
+    expect(Date.now() - t0).toBeLessThan(200); // returned way before the mock's 500ms delay
+  });
+
+  it("a well-behaved backend actually gets cancelled when timeoutMs fires", async () => {
+    let cancelled = false;
+    const model = delayedMockModel(500, { ok: true }, { wellBehaved: true, onAbort: () => (cancelled = true) });
+    await expect(generate(model, { validate: () => true }, "x", { timeoutMs: 30, maxRetries: 1 })).rejects.toBeInstanceOf(TimeoutError);
+    expect(cancelled).toBe(true);
+  });
+
+  it("an externally aborted signal rejects with the abort reason, not TimeoutError", async () => {
+    const controller = new AbortController();
+    const model = delayedMockModel(200, { ok: true }, { wellBehaved: true });
+    const promise = generate(model, { validate: () => true }, "x", { signal: controller.signal, maxRetries: 1 });
+    setTimeout(() => controller.abort(new Error("user cancelled")), 20);
+    await expect(promise).rejects.toThrow("user cancelled");
+  });
+
+  it("an already-aborted signal rejects immediately without ever calling the model", async () => {
+    const controller = new AbortController();
+    controller.abort(new Error("pre-aborted"));
+    let called = false;
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        called = true;
+        return {} as T;
+      },
+    };
+    await expect(generate(model, { validate: () => true }, "x", { signal: controller.signal, maxRetries: 1 })).rejects.toThrow("pre-aborted");
+    expect(called).toBe(false);
+  });
+
+  it("TimeoutError is not retried (propagates immediately, like other non-SchemaViolationError errors)", async () => {
+    let calls = 0;
+    const model: ShapecraftModel = {
+      id: "mock:test",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        calls++;
+        return new Promise<T>((resolve) => setTimeout(() => resolve({} as T), 500));
+      },
+    };
+    await expect(generate(model, { validate: () => true }, "x", { timeoutMs: 20, maxRetries: 5 })).rejects.toBeInstanceOf(TimeoutError);
+    expect(calls).toBe(1);
+  });
+
+  it("stress: many concurrent timed-out calls all reject independently, staying near their own timeout (not serialized)", async () => {
+    const model = delayedMockModel(300, { ok: true }, { wellBehaved: true });
+    const t0 = Date.now();
+    const results = await Promise.allSettled(
+      Array.from({ length: 25 }, () => generate(model, { validate: () => true }, "x", { timeoutMs: 25, maxRetries: 1 }))
+    );
+    const elapsed = Date.now() - t0;
+    expect(results.every((r) => r.status === "rejected")).toBe(true);
+    expect(elapsed).toBeLessThan(250); // ran concurrently, not queued 25x25ms+
+  });
+});
+
+describe("timeoutMs / signal — generateStream()", () => {
+  it("no timeoutMs/signal: streaming behavior is unchanged (regression)", async () => {
+    const model = streamingMockModel(['{"name":', '"Alice",', '"age":30}']);
+    const stream = generateStream(model, z.object({ name: z.string(), age: z.number() }), "x");
+    const result = await stream.result;
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+  });
+
+  it("a hung stream (no next chunk in time) rejects with TimeoutError", async () => {
+    const model = streamingMockModel(["a", "b", "c"], 200); // 200ms between chunks
+    const stream = generateStream(model, { pattern: /.*/ }, "x", { timeoutMs: 30, maxRetries: 1 });
+    await expect(stream.result).rejects.toBeInstanceOf(TimeoutError);
+  });
+
+  it("an external signal aborts an in-progress stream", async () => {
+    const controller = new AbortController();
+    const model = streamingMockModel(["a", "b", "c", "d", "e"], 30);
+    const stream = generateStream(model, { pattern: /.*/ }, "x", { signal: controller.signal, maxRetries: 1 });
+    setTimeout(() => controller.abort(new Error("stop streaming")), 45);
+    await expect(stream.result).rejects.toThrow("stop streaming");
+  });
+});
+
+// ─── 7.4 Pluggable JSON Schema validator ───────────────────────────────────────
+
+describe("jsonSchemaValidator (pluggable)", () => {
+  const schema = { jsonSchema: { type: "object", required: ["name"], properties: { name: { type: "string" } } } };
+
+  it("default (omitted) behavior is unchanged — built-in checkJsonSchema still enforces required fields", async () => {
+    const model = mockModel({});
+    await expect(generate(model, schema, "x", { maxRetries: 1 })).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("a custom validator can be MORE permissive than the built-in default", async () => {
+    const model = mockModel({}); // missing "name" — built-in would reject
+    const permissive = () => {}; // never throws
+    const result = await generate(model, schema, "x", { jsonSchemaValidator: permissive, maxRetries: 1 });
+    expect(result.data).toEqual({});
+  });
+
+  it("a custom validator can be MORE strict than the built-in default", async () => {
+    const model = mockModel({ name: "ab" }); // built-in default would accept this
+    const strict = (value: unknown) => {
+      const v = value as { name?: string };
+      if (!v.name || v.name.length < 3) throw new Error("name must be at least 3 chars");
+    };
+    await expect(generate(model, schema, "x", { jsonSchemaValidator: strict, maxRetries: 1 })).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("applies to generateStream()'s per-field partial validation too", async () => {
+    const objSchema = { jsonSchema: { type: "object", properties: { code: { type: "string" } } } };
+    const model = streamingMockModel(['{"code":', '"AB"}']);
+    const permissiveForCode = (value: unknown) => {
+      // built-in checkJsonSchema has no length constraint; a custom one adds one
+      if (typeof value === "string" && value.length < 5) throw new Error("code too short");
+    };
+    const stream = generateStream(model, objSchema, "x", { jsonSchemaValidator: permissiveForCode, maxRetries: 1 });
+    await expect(stream.result).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+});


### PR DESCRIPTION
## Summary

Four backward-compatible additions on top of the existing `generate()`/`generateStream()` core, cut from `main` at the stream-support merge point (v2.0.1 -> v2.0.2):

- **`createClient()` + middleware** - a Koa-style onion middleware chain (`composeMiddleware`, `loggingMiddleware`) plus client-level `retry`/`timeoutMs`/`jsonSchemaValidator` defaults, so cross-cutting concerns (logging, caching, telemetry) no longer mean editing `generate()` itself.
- **`GenerateResult.metadata`** - every result now carries `{ provider, model, latencyMs, tokens?, finishReason?, requestId?, cost? }`. `provider`/`model`/`latencyMs` are always populated; the rest are reserved for a future backend hook (not populated by any backend yet).
- **`timeoutMs` / `signal`** - bound or cancel a single attempt. Enforced at the core level for every backend (the retry loop always stops waiting, even against a backend that ignores cancellation), and additionally wired into all four built-in backends for real request cancellation. Surfaces as a new `TimeoutError`, never retried.
- **Pluggable `jsonSchemaValidator`** - override the built-in shallow `checkJsonSchema` structural check (swap in AJV, add stricter rules) instead of expanding the built-in checker. Applies to both `generate()`'s final check and `generateStream()`'s per-field incremental validation.

All additive - no existing call to `generate()`/`generateStream()` changes behavior. Full test suite: 151 passing (unchanged pre-existing 2 OpenAI-quota failures, unrelated to this branch).

Also includes an unrelated fix found while dogfooding: `isZodSchema()` used `instanceof z.ZodType`, which breaks when a consumer resolves a different zod module instance/version than shapecraft's own dependency tree (e.g. `file:`-linked local installs) - every Zod schema silently hit "Unknown schema type". Replaced with a duck-typed check (`_def`/`parse`/`safeParse`).

## Example

```typescript
import { createClient, loggingMiddleware, groq, TimeoutError } from "@aviasole/shapecraft";
import { z } from "zod";

const PersonSchema = z.object({ name: z.string(), age: z.number() });

const client = createClient({
  middleware: [loggingMiddleware()],
  retry: { max: 3 },
  timeoutMs: 10_000,
  jsonSchemaValidator: (value, schema) => {
    // swap in your own rules, or AJV, instead of the built-in shallow check
  },
});

try {
  const result = await client.generate(groq({ model: "llama-3.3-70b-versatile" }), PersonSchema, "Extract: Jane Doe, 28");

  console.log(result.data);      // { name: "Jane Doe", age: 28 }
  console.log(result.metadata);  // { provider: "groq", model: "llama-3.3-70b-versatile", latencyMs: 284 }
} catch (err) {
  if (err instanceof TimeoutError) console.error(`Timed out after ${err.timeoutMs}ms`);
}
