### PR TITLE
feat: add model capabilities object and batch generation 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [2.0.3] - 2026-07-06
+
+### Added
+- **`ShapecraftModel.capabilities`** - `{ streaming, chat, structuredOutput, toolCalling }`,
+  an explicit alternative to duck-typing `typeof model.generateStream === "function"`
+  for routing logic. Populated on all 4 built-in backends (`streaming`/`chat`/
+  `structuredOutput` true, `toolCalling` false - no backend supports tool calling
+  yet). Optional field, so any pre-existing custom `ShapecraftModel` implementation
+  without it still satisfies the interface unchanged.
+
 ## [2.0.2] - 2026-07-06
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@
   `structuredOutput` true, `toolCalling` false - no backend supports tool calling
   yet). Optional field, so any pre-existing custom `ShapecraftModel` implementation
   without it still satisfies the interface unchanged.
+- **`generateBatch()` / `client.generateBatch()`** - runs multiple independent
+  `{ model, schema, prompt, options? }` items in parallel, capped at
+  `concurrency` in flight at once (uncapped if omitted). Each item settles
+  independently (`Promise.allSettled`-style, not `Promise.all`-style), so one
+  failing item never loses the results of the rest of the batch. Result order
+  always matches input order regardless of completion order.
+  `client.generateBatch()` routes each item through the client's own
+  `generate()`, so middleware and client-level retry/timeout/validator
+  defaults apply per item, same as a single call.
+
+### Fixed
+- **XML `required` validation missed empty nodes that also carry an attribute**
+  - `<title lang="en"></title>` parses to `{ "@_lang": "en" }`, which has a key
+  and was wrongly treated as non-empty even though its actual text content is
+  blank. `isNonEmpty()` now excludes attribute keys (`@_`-prefixed) from the
+  "has content" check, so a required node with only an attribute and no real
+  text correctly fails validation and retries, instead of silently passing.
 
 ## [2.0.2] - 2026-07-06
 

--- a/README.md
+++ b/README.md
@@ -242,6 +242,26 @@ const local  = ollama({ model: "llama3.2" });
 const claude = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
 ```
 
+### Model Capabilities
+
+Every built-in backend also exposes `capabilities` — an explicit, inspectable alternative to duck-typing `typeof model.generateStream === "function"` for routing logic:
+
+```typescript
+console.log(claude.capabilities);
+// { streaming: true, chat: true, structuredOutput: true, toolCalling: false }
+```
+
+```typescript
+interface ModelCapabilities {
+  streaming: boolean;       // has generateStream()
+  chat: boolean;            // has chat() - required for turnaround: true
+  structuredOutput: boolean; // has generate() - always true
+  toolCalling: boolean;     // not yet supported by any backend
+}
+```
+
+`capabilities` is optional on `ShapecraftModel` — a custom model implementation that predates this field (or simply doesn't set it) still satisfies the interface unchanged, and `model.capabilities` is `undefined` for it. `chat?`/`generateStream?` remain the actual methods the core calls; `capabilities` is just a declared summary of the same information, not a replacement mechanism.
+
 ## Streaming
 
 `generateStream()` streams tokens live for UX, but validates the assembled response exactly once, through the same pipeline as `generate()` — streaming is purely a transport layer, not a different guarantee. Falls back to one-shot `generate()` for a model without streaming support.

--- a/README.md
+++ b/README.md
@@ -348,6 +348,37 @@ const cachingMiddleware: Middleware = async (ctx, next) => {
 
 `createClient()` is purely additive — existing direct calls to `generate()`/`generateStream()` are unaffected. Middleware wraps `generate()` only; `generateStream()` picks up the client's `retry`/`timeoutMs`/`jsonSchemaValidator` defaults but isn't intercepted by middleware (its async-iterable shape doesn't fit the simple before/after `next()` model).
 
+## Batch Generation
+
+Run multiple independent prompts (each with its own model/schema/options) in parallel, capped at `concurrency` in flight at once:
+
+```typescript
+import { generateBatch } from "@aviasole/shapecraft";
+
+const results = await generateBatch(
+  [
+    { model, schema, prompt: "Extract: Jane Doe, 28" },
+    { model, schema, prompt: "Extract: John Smith, 41" },
+    { model, schema, prompt: "Extract: Ada Lovelace, 36" },
+  ],
+  { concurrency: 2 } // omit to run every item concurrently, uncapped
+);
+
+for (const r of results) {
+  if (r.status === "fulfilled") console.log(r.value.data);
+  else console.error("failed:", r.reason);
+}
+```
+
+Each item settles independently - `Promise.allSettled`-style, never `Promise.all`-style - so one bad prompt doesn't lose the results of the rest of the batch. Order is preserved: `results[i]` always corresponds to the item at `items[i]`, regardless of which finishes first.
+
+Available through `createClient()` too, so each item gets the client's middleware/retry/timeout/validator defaults, same as calling `client.generate()` on it individually:
+
+```typescript
+const client = createClient({ retry: { max: 3 } });
+const results = await client.generateBatch(items, { concurrency: 5 });
+```
+
 ## Result Metadata
 
 Every `GenerateResult` includes `metadata`:

--- a/examples/batch.ts
+++ b/examples/batch.ts
@@ -1,0 +1,43 @@
+/**
+ * Example: generateBatch() - parallel generation across multiple prompts.
+ *
+ * Runs each item independently (own model/schema/prompt/options), capped at
+ * `concurrency` in flight at once (uncapped if omitted). Never throws on a
+ * single item's failure - each settles independently, Promise.allSettled-style.
+ */
+import { generateBatch, createClient, groq } from "@aviasole/shapecraft";
+
+const model = groq({ model: "llama-3.3-70b-versatile" });
+
+const schema = {
+  jsonSchema: {
+    type: "object",
+    required: ["name", "age"],
+    properties: { name: { type: "string" }, age: { type: "number" } },
+  },
+};
+
+// ── Standalone: same as calling generate() N times, just parallelized ───────
+const results = await generateBatch(
+  [
+    { model, schema, prompt: "Extract: Jane Doe, 28" },
+    { model, schema, prompt: "Extract: John Smith, 41" },
+    { model, schema, prompt: "Extract: Ada Lovelace, 36" },
+  ],
+  { concurrency: 2 }
+);
+
+for (const r of results) {
+  if (r.status === "fulfilled") console.log("ok:", r.value.data);
+  else console.error("failed:", r.reason);
+}
+
+// ── Through createClient(): each item still gets middleware + client defaults ─
+const client = createClient({ retry: { max: 3 }, timeoutMs: 10_000 });
+
+const batchResults = await client.generateBatch([
+  { model, schema, prompt: "Extract: Jane Doe, 28" },
+  { model, schema, prompt: "Extract: John Smith, 41" },
+]);
+
+console.log(batchResults.map((r) => (r.status === "fulfilled" ? r.value.data : r.reason)));

--- a/examples/capabilities.ts
+++ b/examples/capabilities.ts
@@ -1,0 +1,40 @@
+/**
+ * Example: model.capabilities — explicit feature flags for routing logic.
+ *
+ * An alternative to duck-typing (`typeof model.generateStream === "function"`)
+ * when deciding how to handle a model. All 4 built-in backends populate this;
+ * it's optional so a pre-existing custom ShapecraftModel without it still
+ * satisfies the interface unchanged.
+ */
+import { anthropic, ollama } from "@aviasole/shapecraft";
+import type { ShapecraftModel } from "@aviasole/shapecraft";
+
+const claude = anthropic({ model: "claude-haiku-4-5-20251001" });
+console.log(claude.capabilities);
+// { streaming: true, chat: true, structuredOutput: true, toolCalling: false }
+
+// ── Routing: pick a code path based on declared capabilities, not duck-typing ─
+function describeModel(model: ShapecraftModel): string {
+  if (!model.capabilities) return `${model.id}: capabilities unknown (custom model, assume generate() only)`;
+
+  const features = Object.entries(model.capabilities)
+    .filter(([, supported]) => supported)
+    .map(([name]) => name);
+
+  return `${model.id}: supports ${features.join(", ")}`;
+}
+
+console.log(describeModel(claude));
+console.log(describeModel(ollama({ model: "llama3.2" })));
+
+// ── A minimal custom ShapecraftModel doesn't need to declare capabilities ────
+const bareModel: ShapecraftModel = {
+  id: "custom:bare",
+  guaranteeLevel: "best-effort",
+  async generate() {
+    return { name: "stub" };
+  },
+};
+
+console.log(describeModel(bareModel));
+// custom:bare: capabilities unknown (custom model, assume generate() only)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -23,6 +23,7 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
   return {
     id: `anthropic:${modelId}`,
     guaranteeLevel: "best-effort",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const anthropicClient = await client();

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -24,6 +24,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
   return {
     id: `groq:${modelId}`,
     guaranteeLevel: "native",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const groqClient = await client();

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -31,6 +31,7 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
   return {
     id: `ollama:${options.model}`,
     guaranteeLevel: "constrained",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -43,6 +43,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
   return {
     id: `openai:${modelId}`,
     guaranteeLevel: "native",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const openaiClient = await client();

--- a/src/core/batch.ts
+++ b/src/core/batch.ts
@@ -1,0 +1,40 @@
+import type { BatchItem, BatchResult, GenerateBatchOptions, GenerateResult } from "../types.js";
+import { generate } from "./generate.js";
+
+/**
+ * Runs `items` through `run` with at most `options.concurrency` in flight at
+ * once (uncapped if omitted/<= 0), using a shared-index worker pool so
+ * results stay ordered by input index regardless of completion order. Never
+ * rejects on a single item's failure — each item settles independently,
+ * `Promise.allSettled`-style.
+ */
+export async function runBatch<T>(
+  items: BatchItem<T>[],
+  run: (item: BatchItem<T>) => Promise<GenerateResult<T>>,
+  options: GenerateBatchOptions = {}
+): Promise<BatchResult<T>[]> {
+  const results: BatchResult<T>[] = new Array(items.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const i = nextIndex++;
+      try {
+        results[i] = { status: "fulfilled", value: await run(items[i]!) };
+      } catch (reason) {
+        results[i] = { status: "rejected", reason };
+      }
+    }
+  }
+
+  const concurrency = options.concurrency && options.concurrency > 0 ? options.concurrency : items.length;
+  const workerCount = Math.min(concurrency, items.length);
+  await Promise.all(Array.from({ length: workerCount }, worker));
+
+  return results;
+}
+
+/** Standalone batch entry point — each item runs through the plain top-level `generate()`. */
+export function generateBatch<T>(items: BatchItem<T>[], options?: GenerateBatchOptions): Promise<BatchResult<T>[]> {
+  return runBatch(items, (item) => generate<T>(item.model, item.schema, item.prompt, item.options), options);
+}

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,6 +1,17 @@
-import type { GenerateOptions, GenerateResult, JsonSchemaValidator, SchemaInput, ShapecraftModel, StreamHandle } from "../types.js";
+import type {
+  BatchItem,
+  BatchResult,
+  GenerateBatchOptions,
+  GenerateOptions,
+  GenerateResult,
+  JsonSchemaValidator,
+  SchemaInput,
+  ShapecraftModel,
+  StreamHandle,
+} from "../types.js";
 import { generate } from "./generate.js";
 import { generateStream } from "./stream.js";
+import { runBatch } from "./batch.js";
 import { composeMiddleware } from "./middleware.js";
 import type { Middleware, MiddlewareContext } from "./middleware.js";
 
@@ -18,6 +29,13 @@ export interface CreateClientOptions {
 export interface ShapecraftClient {
   generate<T>(model: ShapecraftModel, schema: SchemaInput<T>, prompt: string, options?: GenerateOptions): Promise<GenerateResult<T>>;
   generateStream<T>(model: ShapecraftModel, schema: SchemaInput<T>, prompt: string, options?: GenerateOptions): StreamHandle<T>;
+  /**
+   * Runs each item through this client's own `generate()` (so middleware and
+   * client-level retry/timeout/validator defaults apply per item, same as a
+   * single call), capped at `options.concurrency` in flight at once. Never
+   * throws on a single item's failure — see `BatchResult`.
+   */
+  generateBatch<T>(items: BatchItem<T>[], options?: GenerateBatchOptions): Promise<BatchResult<T>[]>;
 }
 
 /**
@@ -48,16 +66,20 @@ export function createClient(clientOptions: CreateClientOptions = {}): Shapecraf
     };
   }
 
+  // A plain function (not a `this`-bound method) so generateBatch() below can
+  // call it directly without depending on how the returned object is used.
+  function runGenerate<T>(
+    model: ShapecraftModel,
+    schema: SchemaInput<T>,
+    prompt: string,
+    options: GenerateOptions = {}
+  ): Promise<GenerateResult<T>> {
+    const ctx: MiddlewareContext<T> = { model, schema, prompt, options: mergeOptions(options) };
+    return chain(ctx, () => generate<T>(ctx.model, ctx.schema, ctx.prompt, ctx.options));
+  }
+
   return {
-    generate<T>(
-      model: ShapecraftModel,
-      schema: SchemaInput<T>,
-      prompt: string,
-      options: GenerateOptions = {}
-    ): Promise<GenerateResult<T>> {
-      const ctx: MiddlewareContext<T> = { model, schema, prompt, options: mergeOptions(options) };
-      return chain(ctx, () => generate<T>(ctx.model, ctx.schema, ctx.prompt, ctx.options));
-    },
+    generate: runGenerate,
 
     generateStream<T>(
       model: ShapecraftModel,
@@ -66,6 +88,10 @@ export function createClient(clientOptions: CreateClientOptions = {}): Shapecraf
       options: GenerateOptions = {}
     ): StreamHandle<T> {
       return generateStream<T>(model, schema, prompt, mergeOptions(options));
+    },
+
+    generateBatch<T>(items: BatchItem<T>[], options?: GenerateBatchOptions): Promise<BatchResult<T>[]> {
+      return runBatch(items, (item) => runGenerate<T>(item.model, item.schema, item.prompt, item.options), options);
     },
   };
 }

--- a/src/core/xml.ts
+++ b/src/core/xml.ts
@@ -57,9 +57,11 @@ export function stripXmlProlog(xml: string): string {
 
 // ─── XML parser ───────────────────────────────────────────────────────────────
 
+const ATTR_PREFIX = "@_";
+
 const parser = new XMLParser({
   ignoreAttributes: false,
-  attributeNamePrefix: "@_",
+  attributeNamePrefix: ATTR_PREFIX,
   isArray: () => false,
   parseTagValue: true,
   trimValues: true,
@@ -67,7 +69,7 @@ const parser = new XMLParser({
 
 const builder = new XMLBuilder({
   ignoreAttributes: false,
-  attributeNamePrefix: "@_",
+  attributeNamePrefix: ATTR_PREFIX,
   format: true,
   indentBy: "  ",
   suppressBooleanAttributes: false,
@@ -185,7 +187,15 @@ function isNonEmpty(value: unknown): boolean {
   if (value === null || value === undefined) return false;
   if (typeof value === "string") return value.trim().length > 0;
   if (Array.isArray(value)) return value.length > 0 && value.some(isNonEmpty);
-  if (typeof value === "object") return Object.keys(value).length > 0;
+  if (typeof value === "object") {
+    // Attribute keys (parsed with ATTR_PREFIX) don't count as content on their
+    // own — an element can carry a real attribute yet still have empty text,
+    // e.g. `<title lang="en"></title>` parses to `{ "@_lang": "en" }`, which
+    // has a key but no actual text/child content.
+    return Object.entries(value as Record<string, unknown>).some(
+      ([key, v]) => !key.startsWith(ATTR_PREFIX) && isNonEmpty(v)
+    );
+  }
   return true; // numbers, booleans
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export * from "./backends/index.js";
 export type {
   ShapecraftModel,
   ModelCallOptions,
+  ModelCapabilities,
   SchemaInput,
   GenerateOptions,
   GenerateResult,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export { generate } from "./core/generate.js";
 export { generateStream } from "./core/stream.js";
+export { generateBatch } from "./core/batch.js";
 export { toJsonSchema, buildStructuredPrompt } from "./core/schema.js";
 export { xmlType, validateXmlTemplate } from "./core/xml.js";
 export { createConversationMemory, COMPLETION_SENTINEL } from "./core/turnaround.js";
@@ -26,6 +27,9 @@ export type {
   TurnResult,
   StreamEvent,
   StreamHandle,
+  BatchItem,
+  BatchResult,
+  GenerateBatchOptions,
 } from "./types.js";
 
 export type { CreateClientOptions, ShapecraftClient } from "./core/client.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -141,6 +141,26 @@ export interface GenerateResult<T> {
   metadata: ResultMetadata;
 }
 
+/** One independent unit of work for `generateBatch()`/`client.generateBatch()`. */
+export interface BatchItem<T = unknown> {
+  model: ShapecraftModel;
+  schema: SchemaInput<T>;
+  prompt: string;
+  options?: GenerateOptions;
+}
+
+/**
+ * Settled outcome for one `BatchItem` — mirrors `Promise.allSettled`'s shape
+ * rather than throwing, so one failing item never loses the results of the
+ * rest of the batch.
+ */
+export type BatchResult<T> = { status: "fulfilled"; value: GenerateResult<T> } | { status: "rejected"; reason: unknown };
+
+export interface GenerateBatchOptions {
+  /** Max number of items in flight at once. Omit (or <= 0) to run every item concurrently, uncapped. */
+  concurrency?: number;
+}
+
 export class SchemaViolationError extends Error {
   constructor(
     public readonly raw: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -49,9 +49,27 @@ export interface ModelCallOptions {
   signal?: AbortSignal;
 }
 
+/**
+ * Explicit, inspectable feature flags for a model — an alternative to
+ * duck-typing `typeof model.chat === "function"` / `typeof model.generateStream
+ * === "function"` for routing logic. Optional so any pre-existing custom
+ * `ShapecraftModel` implementation (which predates this field) still
+ * satisfies the interface unchanged; the 4 built-in backends always populate
+ * it. `chat?`/`generateStream?` themselves are untouched and still the
+ * source of truth the core actually calls — `capabilities` is a declared
+ * summary of the same information, not a replacement mechanism.
+ */
+export interface ModelCapabilities {
+  streaming: boolean;
+  chat: boolean;
+  structuredOutput: boolean;
+  toolCalling: boolean;
+}
+
 export interface ShapecraftModel {
   id: string;
   guaranteeLevel: GuaranteeLevel;
+  capabilities?: ModelCapabilities;
   generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T>;
   /**
    * Plain, unconstrained conversational turn (no schema/JSON mode imposed).

--- a/tests/batch.test.ts
+++ b/tests/batch.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from "vitest";
+import { generateBatch } from "../src/core/batch.js";
+import { createClient } from "../src/core/client.js";
+import { mockModel } from "./helpers/index.js";
+import type { ShapecraftModel } from "../src/types.js";
+
+function delayedMockModel(ms: number, returnValue: unknown, opts: { fail?: boolean; onStart?: () => void; onEnd?: () => void } = {}): ShapecraftModel {
+  return {
+    id: "mock:batch",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      opts.onStart?.();
+      await new Promise((resolve) => setTimeout(resolve, ms));
+      opts.onEnd?.();
+      if (opts.fail) throw new Error("boom");
+      return returnValue as T;
+    },
+  };
+}
+
+describe("generateBatch (standalone)", () => {
+  it("runs every item and preserves result order by index", async () => {
+    const results = await generateBatch([
+      { model: mockModel({ n: 1 }), schema: { validate: () => true }, prompt: "a" },
+      { model: mockModel({ n: 2 }), schema: { validate: () => true }, prompt: "b" },
+      { model: mockModel({ n: 3 }), schema: { validate: () => true }, prompt: "c" },
+    ]);
+
+    expect(results).toHaveLength(3);
+    expect(results.map((r) => (r.status === "fulfilled" ? r.value.data : null))).toEqual([{ n: 1 }, { n: 2 }, { n: 3 }]);
+  });
+
+  it("settles independently — one item failing doesn't affect the others", async () => {
+    const results = await generateBatch([
+      { model: mockModel({ ok: true }), schema: { validate: () => true }, prompt: "a" },
+      { model: mockModel(null, true), schema: { validate: () => true }, prompt: "b", options: { maxRetries: 1 } },
+      { model: mockModel({ ok: true }), schema: { validate: () => true }, prompt: "c" },
+    ]);
+
+    expect(results[0]).toMatchObject({ status: "fulfilled" });
+    expect(results[1]!.status).toBe("rejected");
+    expect(results[2]).toMatchObject({ status: "fulfilled" });
+  });
+
+  it("returns an empty array immediately for an empty batch", async () => {
+    const results = await generateBatch([]);
+    expect(results).toEqual([]);
+  });
+
+  it("with no concurrency cap, runs every item in parallel (not serialized)", async () => {
+    const n = 5;
+    const items = Array.from({ length: n }, (_, i) => ({
+      model: delayedMockModel(50, { i }),
+      schema: { validate: () => true },
+      prompt: `p${i}`,
+    }));
+
+    const t0 = Date.now();
+    await generateBatch(items);
+    const elapsed = Date.now() - t0;
+
+    // Serialized would be ~5*50=250ms; parallel should be close to one 50ms slot.
+    expect(elapsed).toBeLessThan(150);
+  });
+
+  it("concurrency cap limits how many run at once", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const items = Array.from({ length: 6 }, (_, i) => ({
+      model: delayedMockModel(30, { i }, {
+        onStart: () => {
+          inFlight++;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+        },
+        onEnd: () => inFlight--,
+      }),
+      schema: { validate: () => true },
+      prompt: `p${i}`,
+    }));
+
+    await generateBatch(items, { concurrency: 2 });
+
+    expect(maxInFlight).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("client.generateBatch()", () => {
+  it("routes each item through the client's own generate() — middleware runs once per item", async () => {
+    const order: string[] = [];
+    const client = createClient({
+      middleware: [
+        async (ctx, next) => {
+          order.push(`start:${ctx.prompt}`);
+          const result = await next();
+          order.push(`end:${ctx.prompt}`);
+          return result;
+        },
+      ],
+    });
+
+    const results = await client.generateBatch([
+      { model: mockModel({ ok: true }), schema: { validate: () => true }, prompt: "one" },
+      { model: mockModel({ ok: true }), schema: { validate: () => true }, prompt: "two" },
+    ]);
+
+    expect(results).toHaveLength(2);
+    expect(order).toContain("start:one");
+    expect(order).toContain("end:one");
+    expect(order).toContain("start:two");
+    expect(order).toContain("end:two");
+  });
+
+  it("applies the client's retry default to each item", async () => {
+    let calls = 0;
+    const flaky = mockModel(null, true);
+    const countingModel: ShapecraftModel = {
+      ...flaky,
+      async generate<T>(): Promise<T> {
+        calls++;
+        return flaky.generate<T>("", { validate: () => true });
+      },
+    };
+
+    const client = createClient({ retry: { max: 2 } });
+    const results = await client.generateBatch([{ model: countingModel, schema: { validate: () => true }, prompt: "x" }]);
+
+    expect(results[0]!.status).toBe("rejected");
+    expect(calls).toBe(2);
+  });
+});

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { generate } from "../src/core/generate.js";
+import { openai } from "../src/backends/openai.js";
+import { groq } from "../src/backends/groq.js";
+import { anthropic } from "../src/backends/anthropic.js";
+import { ollama } from "../src/backends/ollama.js";
+import { mockModel } from "./helpers/index.js";
+
+const PersonSchema = z.object({ name: z.string(), age: z.number() });
+
+describe("ShapecraftModel.capabilities", () => {
+  it.each([
+    ["openai", openai({ model: "gpt-4o-mini" })],
+    ["groq", groq({ model: "llama-3.3-70b-versatile" })],
+    ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
+    ["ollama", ollama({ model: "llama3.2" })],
+  ])("%s exposes streaming/chat/structuredOutput true, toolCalling false", (_name, model) => {
+    expect(model.capabilities).toEqual({
+      streaming: true,
+      chat: true,
+      structuredOutput: true,
+      toolCalling: false,
+    });
+  });
+
+  it.each([
+    ["openai", openai({ model: "gpt-4o-mini" })],
+    ["groq", groq({ model: "llama-3.3-70b-versatile" })],
+    ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
+    ["ollama", ollama({ model: "llama3.2" })],
+  ])("%s's declared capabilities match its actual duck-typed method presence", (_name, model) => {
+    expect(model.capabilities?.streaming).toBe(typeof model.generateStream === "function");
+    expect(model.capabilities?.chat).toBe(typeof model.chat === "function");
+  });
+
+  it("is optional — a pre-existing custom ShapecraftModel without capabilities still satisfies the interface and works", async () => {
+    const legacy = mockModel({ name: "Alice", age: 30 });
+    expect(legacy.capabilities).toBeUndefined();
+
+    const result = await generate(legacy, PersonSchema, "get person");
+    expect(result.data).toEqual({ name: "Alice", age: 30 });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ShapecraftModel.capabilities` - `{ streaming, chat, structuredOutput, toolCalling }`, an explicit alternative to duck-typing `typeof model.generateStream === "function"` for routing logic. Populated on all 4 built-in backends; optional field, so any pre-existing custom `ShapecraftModel` still satisfies the interface unchanged.
- Adds `generateBatch()` / `client.generateBatch()` - runs multiple independent `{ model, schema, prompt, options? }` items in parallel, capped at `concurrency` in flight (uncapped if omitted).
- Batch results settle independently (`Promise.allSettled`-style), so one failing item never loses the rest of the batch; result order always matches input order regardless of completion order.
- `client.generateBatch()` routes each item through the client's own `generate()`, so middleware and client-level retry/timeout/validator defaults apply per item, same as a single call.
- Fixes an XML `required` validation bug where an empty node with only an attribute (e.g. `<title lang="en"></title>`) was wrongly treated as non-empty.
- Bumps version to 2.0.3, updates CHANGELOG and README with examples for both features.

## Test plan
- [x] Existing test suite passes
- [x] New capabilities test suite (`tests/capabilities.test.ts`)
- [x] New batch generation test suite (`tests/batch.test.ts`)
