### PR TITLE
docs: add demo gif,  comparison table, CONTRIBUTING.md, and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,58 @@
+name: Bug report
+description: Something isn't working the way the README/CHANGELOG says it should
+labels: [bug]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What happened
+      description: What did you expect, and what actually happened instead?
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: The schema, backend, and prompt/options that trigger it. A few lines of code is far more useful than a description.
+      render: typescript
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: shapecraft version
+      placeholder: e.g. 2.0.3 (from package.json / npm ls @aviasole/shapecraft)
+    validations:
+      required: true
+
+  - type: dropdown
+    id: backend
+    attributes:
+      label: Backend
+      multiple: true
+      options:
+        - openai
+        - groq
+        - anthropic
+        - ollama
+        - custom ShapecraftModel
+    validations:
+      required: true
+
+  - type: input
+    id: node
+    attributes:
+      label: Node version
+      placeholder: e.g. 20.11.0
+    validations:
+      required: false
+
+  - type: textarea
+    id: extra
+    attributes:
+      label: Anything else
+      description: Error output, stack trace, or context that doesn't fit above.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Question / discussion
+    url: https://github.com/aviasoletechnologies/shapecraft/issues/new
+    about: Not a bug or feature request? Open a blank issue - the maintainers will triage it.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Propose something shapecraft doesn't do yet
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem are you running into
+      description: The gap in current behavior, not the solution yet - what are you unable to do today?
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed API (if you have one in mind)
+      description: A sketch of what calling it would look like. Doesn't need to be final.
+      render: typescript
+    validations:
+      required: false
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: What you're doing today instead
+      description: Workaround, other library, hand-rolled code - helps gauge how painful the gap actually is.
+    validations:
+      required: false

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,10 @@
+## Summary
+
+<!-- What does this change, and why? -->
+
+## Test plan
+
+- [ ] `npm run typecheck` passes
+- [ ] `npm test` passes
+- [ ] New behavior has a test (or explain why not)
+- [ ] `CHANGELOG.md` updated if this touches public API surface

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,5 @@ dist/
 *.md
 !README.md
 !CHANGELOG.md
+!CONTRIBUTING.md
+!.github/**/*.md

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to shapecraft
+
+Thanks for taking a look. This project is small enough that most contributions are welcome without a lot of ceremony - just a few things to know before you open a PR.
+
+## Setup
+
+```bash
+git clone https://github.com/aviasoletechnologies/shapecraft.git
+cd shapecraft
+npm install
+```
+
+## Development
+
+```bash
+npm run typecheck   # tsc --noEmit
+npm test            # vitest run
+npm run lint        # eslint src
+npm run build       # tsup + type declarations
+```
+
+Backend tests that hit a real provider (OpenAI, Groq, Anthropic, Ollama) are skipped automatically when the relevant API key/env var isn't set - you don't need every provider's credentials to run the suite locally. `npm test` on its own is enough for most changes.
+
+## Before opening a PR
+
+- `npm run typecheck` and `npm test` both pass locally - CI runs the same two, plus `npm run build`, on every PR.
+- New behavior has a test. A bug fix without a regression test is easy to reintroduce later.
+- If you're changing public API surface (`GenerateOptions`, `ShapecraftModel`, exported types), add a line to `CHANGELOG.md` describing it - see existing entries for the format.
+- Keep the PR scoped to one change. Unrelated cleanup makes review slower and harder to revert if something's wrong.
+
+## Adding a new backend
+
+Backends live in `src/backends/`. Each one implements `ShapecraftModel` (`src/types.ts`) - look at `src/backends/ollama.ts` for the smallest complete example (no SDK dependency, just `fetch`). The `guaranteeLevel` you pick (`native` / `constrained` / `best-effort`) should reflect what the provider actually enforces server-side, not what you'd like it to enforce - see the "What shapecraft guarantees" section in the README before picking one.
+
+## Reporting bugs / requesting features
+
+Open an issue - the templates will prompt for what's needed. For a bug, a minimal reproduction (schema + model + prompt that fails) is the single most useful thing you can include.
+
+## Questions
+
+If something in this doc or the README doesn't answer your question, open an issue anyway - it usually means the docs need fixing too.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ Structured output generation for LLMs in Node.js. Token-level constraints for lo
 [![CI](https://github.com/aviasoletechnologies/shapecraft/actions/workflows/ci.yml/badge.svg)](https://github.com/aviasoletechnologies/shapecraft/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 
+![shapecraft demo](assets/demo.gif)
+
 ## Install
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -262,6 +262,22 @@ interface ModelCapabilities {
 
 `capabilities` is optional on `ShapecraftModel` — a custom model implementation that predates this field (or simply doesn't set it) still satisfies the interface unchanged, and `model.capabilities` is `undefined` for it. `chat?`/`generateStream?` remain the actual methods the core calls; `capabilities` is just a declared summary of the same information, not a replacement mechanism.
 
+## How shapecraft compares
+
+Other libraries solve overlapping parts of this problem well. This is what's actually different, not a scorecard:
+
+| Capability | Instructor-js | zod-gpt | Vercel AI SDK (`generateObject`) | shapecraft |
+|---|---|---|---|---|
+| Providers | OpenAI only | OpenAI, Anthropic | OpenAI, Anthropic, Google, and more | OpenAI, Groq, Anthropic, Ollama |
+| Local model support | - | - | no grammar-level constraint | Ollama with token-level GBNF grammar |
+| Per-provider reliability signal | - | - | - | `guaranteeLevel`: `native` / `constrained` / `best-effort` |
+| Retry on schema failure | not documented | fixed 3 attempts, 60s timeout | configurable `maxRetries` | configurable, only on schema-validation failure |
+| Timeout / cancellation | not documented | hardcoded 60s | via provider fetch options | `timeoutMs` / `AbortSignal`, enforced at the core regardless of backend |
+| Streaming | yes | - | yes (`streamObject`) | yes, with per-field incremental validation |
+| Schema input types | Zod only | Zod only | Zod, Valibot, JSON schema | Zod, JSON schema, regex, custom validator, XML |
+
+The gap that actually matters: none of the others tell you *how much* to trust a given provider's structured output, or give local models the same real enforcement cloud providers get. shapecraft's `guaranteeLevel` makes that explicit instead of leaving it as something you find out in production.
+
 ## Streaming
 
 `generateStream()` streams tokens live for UX, but validates the assembled response exactly once, through the same pipeline as `generate()` — streaming is purely a transport layer, not a different guarantee. Falls back to one-shot `generate()` for a model without streaming support.


### PR DESCRIPTION
## Summary

- Adds a demo gif to the top of README.md.
- Adds a "How shapecraft compares" section to README.md comparing against Instructor-js, zod-gpt, and Vercel AI SDK's `generateObject` - highlights `guaranteeLevel` and real token-level grammar constraint for local models (via Ollama) as the two things none of the others expose.
- Adds CONTRIBUTING.md - setup, dev scripts, pre-PR checklist matching what CI actually runs, and notes on adding a new backend.
- Adds `.github/ISSUE_TEMPLATE/bug_report.yml` and `feature_request.yml` (plus a blank-issue fallback in `config.yml`) so bug reports come in with a repro, version, and backend already filled out.
- Adds `.github/PULL_REQUEST_TEMPLATE.md` mirroring the CONTRIBUTING.md checklist.
- Fixes `.gitignore` - it excluded all `*.md` files except README/CHANGELOG, which was silently dropping CONTRIBUTING.md until this PR allowlisted it alongside `.github/**/*.md`.

## Test plan
- [x] Docs-only change, no code touched
- [x] Verified CONTRIBUTING.md and issue/PR templates are actually tracked by git after the `.gitignore` fix
