### PR TITLE
feat: streaming parser refactor and staged validation pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,9 +94,6 @@
   streaming-parser-refactor item in PLAN-Updated.md). `turnaround` calls are also
   out of scope for the client wrapper in v1 — use top-level
   `generate(..., { turnaround: true })`.
-- This branch (`architecture-hardening`) was cut from `main` at the stream-support
-  merge point, independent of the (still unmerged) fhir-support/gbnf-support
-  branches — those lineages will need reconciling on merge.
 
 ## [2.0.1] - 2026-07-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## [2.0.4] - 2026-07-10
+
+### Added
+
+- **Staged validation pipeline** - `generate()`'s validation step is now
+  `parse → structural validation → semantic validation → confidence scoring →
+  post-processors → return`. Structural validation (`validateOutput`) is
+  unchanged and remains the only required stage; the three new stages are
+  opt-in via `GenerateOptions` (also settable as `createClient()` defaults,
+  same override pattern as `jsonSchemaValidator`):
+  - `semanticValidator(value, { prompt })` - a content/meaning check that runs
+    after structural validation passes. Throw to fail; the failure is wrapped
+    in `SchemaViolationError` so it retries exactly like a structural failure.
+  - `confidenceScorer(value, { prompt })` - returns a 0-1 score, exposed as
+    `GenerateResult.confidence`. Purely informational unless `minConfidence`
+    is also set, in which case a score below the threshold fails the attempt
+    and retries.
+  - `postProcessors: PostProcessor[]` - run last, in array order, reshaping
+    an already-validated value (normalization, enrichment, etc). Never
+    retried - only runs once every check has already passed.
+
+  Wired into `generate()` only; `generateStream()`'s per-field incremental
+  validation is untouched (deferred to the streaming parser refactor).
+
 ## [2.0.3] - 2026-07-06
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -451,6 +451,28 @@ const result = await generate(model, { jsonSchema: PersonJsonSchema }, prompt, {
 
 Applies to both `generate()`'s final check and `generateStream()`'s per-field incremental (`partial`) validation, so a custom validator behaves consistently whether or not you're streaming. Omit it and you get today's `checkJsonSchema` behavior, unchanged.
 
+## Staged Validation Pipeline
+
+`generate()`'s validation step is a pipeline: `parse → structural validation → semantic validation → confidence scoring → post-processors → return`. Structural validation is unchanged and the only required stage — the rest are opt-in.
+
+```typescript
+const result = await generate(model, PersonSchema, prompt, {
+  // runs after structural validation passes — throw to fail (retries, same as a schema violation)
+  semanticValidator: (value, { prompt }) => {
+    if (!prompt.includes(value.name)) throw new Error(`"${value.name}" not grounded in source text`);
+  },
+  // returns a 0-1 score, exposed as result.confidence
+  confidenceScorer: (value) => (value.name.length > 1 ? 0.9 : 0.3),
+  minConfidence: 0.5, // a score below this also fails the attempt and retries
+  // runs last, in array order, on a value that already passed every check above
+  postProcessors: [(value) => ({ ...value, name: value.name.trim() })],
+});
+
+console.log(result.confidence); // 0.9
+```
+
+All three are also settable as `createClient()` defaults, following the same per-call-overrides-client-default pattern as `jsonSchemaValidator`. Only `generate()` runs the full pipeline today — `generateStream()`'s per-field incremental checks still use `checkJsonSchema`/your `jsonSchemaValidator` only.
+
 ## What shapecraft guarantees — and what it doesn't
 
 Every mechanism above (`native`, `constrained`, `best-effort` + retry) targets one thing: **the output is structurally valid** — it parses, the types match, required fields are present and non-empty. That's a real, load-bearing guarantee: it's the difference between code that can trust `result.data.age` is a `number` versus code that has to defensively re-check everything the model says.
@@ -460,7 +482,7 @@ What it doesn't cover is **whether a value is actually true.** A schema (or GBNF
 So think of it as two layers:
 
 - **Structural correctness** (shapecraft's job): valid JSON/XML, correct types, required fields present. Solved.
-- **Semantic correctness** ("is this value actually grounded in the input?"): a separate concern shapecraft doesn't attempt today. If your use case needs that guarantee — financial data, dates, anything where a plausible-but-wrong value is costly — pair shapecraft with your own grounding check (e.g. verifying extracted values trace back to the source text) or a second-pass verifier, rather than trusting `required` alone.
+- **Semantic correctness** ("is this value actually grounded in the input?"): shapecraft doesn't check this for you by default — `required`/type-checking alone can't. What it does provide is the hook: `semanticValidator` in the [Staged Validation Pipeline](#staged-validation-pipeline) runs your own grounding check (e.g. verifying an extracted value traces back to the source text) after structural validation passes, and fails/retries the attempt exactly like a schema violation if it doesn't hold. If your use case needs that guarantee — financial data, dates, anything where a plausible-but-wrong value is costly — write that check and pass it in, rather than trusting `required` alone.
 
 This isn't a reason to avoid structural validation — it eliminates an entire class of bugs (parse errors, wrong types, missing fields) that would otherwise hit you in production. It just isn't the same guarantee as "this value is correct," and knowing the boundary is what lets you build the right check on top for the cases that need one.
 
@@ -482,6 +504,10 @@ const result = await generate(model, schema, prompt, {
 | `timeoutMs` | bound a single attempt's wall-clock time — see [Timeouts & Cancellation](#timeouts--cancellation) |
 | `signal` | an `AbortSignal` to cancel an in-flight attempt — see [Timeouts & Cancellation](#timeouts--cancellation) |
 | `jsonSchemaValidator` | override the built-in `jsonSchema` structural check — see [Pluggable JSON Schema Validation](#pluggable-json-schema-validation) |
+| `semanticValidator` | content/grounding check after structural validation passes — see [Staged Validation Pipeline](#staged-validation-pipeline) |
+| `confidenceScorer` | assigns a 0-1 score to `result.confidence` — see [Staged Validation Pipeline](#staged-validation-pipeline) |
+| `minConfidence` | fails and retries the attempt if `confidenceScorer`'s score is below this |
+| `postProcessors` | array of transforms applied in order to an already-validated value — see [Staged Validation Pipeline](#staged-validation-pipeline) |
 
 ## Error Handling
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/core/client.ts
+++ b/src/core/client.ts
@@ -1,11 +1,14 @@
 import type {
   BatchItem,
   BatchResult,
+  ConfidenceScorer,
   GenerateBatchOptions,
   GenerateOptions,
   GenerateResult,
   JsonSchemaValidator,
+  PostProcessor,
   SchemaInput,
+  SemanticValidator,
   ShapecraftModel,
   StreamHandle,
 } from "../types.js";
@@ -24,6 +27,14 @@ export interface CreateClientOptions {
   timeoutMs?: number;
   /** Default pluggable JSON Schema validator (see `GenerateOptions.jsonSchemaValidator`) for every call through this client. */
   jsonSchemaValidator?: JsonSchemaValidator;
+  /** Default semantic validation stage (see `GenerateOptions.semanticValidator`) for every call through this client. */
+  semanticValidator?: SemanticValidator<unknown>;
+  /** Default confidence scoring stage (see `GenerateOptions.confidenceScorer`) for every call through this client. */
+  confidenceScorer?: ConfidenceScorer<unknown>;
+  /** Default minimum confidence threshold (see `GenerateOptions.minConfidence`) for every call through this client. */
+  minConfidence?: number;
+  /** Default post-processing stage (see `GenerateOptions.postProcessors`) for every call through this client. */
+  postProcessors?: PostProcessor<unknown>[];
 }
 
 export interface ShapecraftClient {
@@ -62,6 +73,10 @@ export function createClient(clientOptions: CreateClientOptions = {}): Shapecraf
       ...(clientOptions.retry?.max !== undefined ? { maxRetries: clientOptions.retry.max } : {}),
       ...(clientOptions.timeoutMs !== undefined ? { timeoutMs: clientOptions.timeoutMs } : {}),
       ...(clientOptions.jsonSchemaValidator !== undefined ? { jsonSchemaValidator: clientOptions.jsonSchemaValidator } : {}),
+      ...(clientOptions.semanticValidator !== undefined ? { semanticValidator: clientOptions.semanticValidator } : {}),
+      ...(clientOptions.confidenceScorer !== undefined ? { confidenceScorer: clientOptions.confidenceScorer } : {}),
+      ...(clientOptions.minConfidence !== undefined ? { minConfidence: clientOptions.minConfidence } : {}),
+      ...(clientOptions.postProcessors !== undefined ? { postProcessors: clientOptions.postProcessors } : {}),
       ...options, // per-call options always win over client-level defaults
     };
   }

--- a/src/core/generate.ts
+++ b/src/core/generate.ts
@@ -1,14 +1,17 @@
 import type {
+  ConfidenceScorer,
   GenerateOptions,
   GenerateResult,
+  PostProcessor,
   ResultMetadata,
   SchemaInput,
+  SemanticValidator,
   ShapecraftModel,
   TurnaroundOptions,
   TurnResult,
 } from "../types.js";
 import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
-import { validateOutput } from "./validate.js";
+import { runValidationPipeline } from "./validate.js";
 import { runTurnaround } from "./turnaround.js";
 import { createTimeoutGuard } from "./timeout.js";
 
@@ -42,7 +45,8 @@ export async function generate<T>(
   }
 
   const maxRetries = options.maxRetries ?? 3;
-  const { systemPrompt, timeoutMs, signal, jsonSchemaValidator } = options;
+  const { systemPrompt, timeoutMs, signal, jsonSchemaValidator, semanticValidator, confidenceScorer, minConfidence, postProcessors } =
+    options;
   const { provider, model: modelName } = parseProviderModel(model.id);
 
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
@@ -57,13 +61,20 @@ export async function generate<T>(
         model.generate<T>(prompt, schema, systemPrompt, callSignal ? { signal: callSignal } : undefined),
         guard,
       ]);
-      const data = validateOutput<T>(raw, schema, { jsonSchemaValidator });
+      const { data, confidence } = await runValidationPipeline<T>(raw, schema, prompt, {
+        jsonSchemaValidator,
+        semanticValidator: semanticValidator as SemanticValidator<T> | undefined,
+        confidenceScorer: confidenceScorer as ConfidenceScorer<T> | undefined,
+        minConfidence,
+        postProcessors: postProcessors as PostProcessor<T>[] | undefined,
+      });
       const metadata: ResultMetadata = { provider, model: modelName, latencyMs: Date.now() - t0 };
       return {
         data,
         guaranteeLevel: model.guaranteeLevel,
         attempts: attempt,
         metadata,
+        ...(confidence === undefined ? {} : { confidence }),
       };
     } catch (err) {
       if (!(err instanceof SchemaViolationError)) throw err;

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -1,58 +1,23 @@
-import type { GenerateOptions, GenerateResult, ResultMetadata, SchemaInput, ShapecraftModel, StreamEvent, StreamHandle } from "../types.js";
+import type { GenerateOptions, GenerateResult, ResultMetadata, SchemaInput, ShapecraftModel, StreamHandle } from "../types.js";
 import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
 import { generate, parseProviderModel } from "./generate.js";
 import { parseAndValidate } from "./parse.js";
-import { extractCompletedTopLevelFields, validateFieldIfPossible } from "./incremental.js";
 import { createTimeoutGuard } from "./timeout.js";
+import { tokenize } from "./streaming/tokenizer.js";
+import { IncrementalParser } from "./streaming/incremental-parser.js";
+import { validateFieldIfPossible } from "./streaming/validator.js";
+import { StreamEmitter } from "./streaming/emitter.js";
 
 /**
- * Single-consumer async channel. textStream and events are two independent
- * channels fed by the same pump — each is meant to be iterated by at most one
- * consumer, matching how streamGenerate()'s two views are actually used.
+ * Orchestrates the four streaming stages per attempt:
+ *
+ *   Tokenizer (tokenize) -> Incremental Parser (IncrementalParser) ->
+ *   Validator (validateFieldIfPossible / parseAndValidate) -> Emitter (StreamEmitter)
+ *
+ * This function owns only the retry/timeout/abort control flow - each stage
+ * is an independent, separately testable unit that knows nothing about the
+ * others.
  */
-function createChannel<T>(): { push(item: T): void; end(): void; iterable: AsyncIterable<T> } {
-  const buffer: T[] = [];
-  let ended = false;
-  let waiting: ((result: IteratorResult<T>) => void) | null = null;
-
-  function push(item: T): void {
-    if (ended) return;
-    if (waiting) {
-      const resolve = waiting;
-      waiting = null;
-      resolve({ value: item, done: false });
-    } else {
-      buffer.push(item);
-    }
-  }
-
-  function end(): void {
-    if (ended) return;
-    ended = true;
-    if (waiting) {
-      const resolve = waiting;
-      waiting = null;
-      resolve({ value: undefined as unknown as T, done: true });
-    }
-  }
-
-  const iterable: AsyncIterable<T> = {
-    [Symbol.asyncIterator]() {
-      return {
-        next(): Promise<IteratorResult<T>> {
-          if (buffer.length > 0) return Promise.resolve({ value: buffer.shift() as T, done: false });
-          if (ended) return Promise.resolve({ value: undefined as unknown as T, done: true });
-          return new Promise((resolve) => {
-            waiting = resolve;
-          });
-        },
-      };
-    },
-  };
-
-  return { push, end, iterable };
-}
-
 export function generateStream<T>(
   model: ShapecraftModel,
   schema: SchemaInput<T>,
@@ -63,8 +28,7 @@ export function generateStream<T>(
   const { systemPrompt, timeoutMs, signal, jsonSchemaValidator } = options;
   const { provider, model: modelName } = parseProviderModel(model.id);
 
-  const textChannel = createChannel<string>();
-  const eventChannel = createChannel<StreamEvent<T>>();
+  const emitter = new StreamEmitter<T>();
 
   let resolveResult!: (result: GenerateResult<T>) => void;
   let rejectResult!: (error: unknown) => void;
@@ -73,112 +37,80 @@ export function generateStream<T>(
     rejectResult = reject;
   });
 
-  function emit(event: StreamEvent<T>): void {
-    eventChannel.push(event);
-    if (event.type === "delta") textChannel.push(event.text);
-  }
-
-  function finish(): void {
-    eventChannel.end();
-    textChannel.end();
-  }
-
   async function pump(): Promise<void> {
-    // No streaming support on this model — fall back to one-shot generate(),
+    // No streaming support on this model - fall back to one-shot generate(),
     // and surface its full output as a single delta so textStream still works.
     if (!model.generateStream) {
-      emit({ type: "attempt-start", attempt: 1 });
+      emitter.emit({ type: "attempt-start", attempt: 1 });
       const finalResult = await generate<T>(model, schema, prompt, options);
       const text = typeof finalResult.data === "string" ? finalResult.data : JSON.stringify(finalResult.data, null, 2);
-      emit({ type: "delta", text, attempt: 1 });
-      emit({ type: "done", result: finalResult });
-      finish();
+      emitter.emit({ type: "delta", text, attempt: 1 });
+      emitter.emit({ type: "done", result: finalResult });
+      emitter.finish();
       resolveResult(finalResult);
       return;
     }
 
     for (let attempt = 1; attempt <= maxRetries; attempt++) {
-      // Fail fast on an already-aborted signal — skip calling the backend
+      // Fail fast on an already-aborted signal - skip calling the backend
       // entirely rather than invoking it just to have the race discard it.
       if (signal?.aborted) {
-        finish();
+        emitter.finish();
         rejectResult(signal.reason ?? new DOMException("Aborted", "AbortError"));
         return;
       }
 
       const t0 = Date.now();
-      emit({ type: "attempt-start", attempt });
-      let buffer = "";
-      const validatedKeys = new Set<string>();
+      emitter.emit({ type: "attempt-start", attempt });
+
+      const parser = new IncrementalParser();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const partialValue: Record<string, unknown> = {};
       let earlyFailure: SchemaViolationError | null = null;
 
       const { guard, signal: callSignal, cleanup } = createTimeoutGuard(timeoutMs, signal);
-      const iterator = model.generateStream<T>(
+      const source = model.generateStream<T>(
         prompt,
         schema,
         systemPrompt,
         callSignal ? { signal: callSignal } : undefined
-      )[Symbol.asyncIterator]();
+      );
 
       try {
-        while (true) {
-          // Race each chunk (not the whole stream) against the shared guard,
-          // so a hung backend that never yields a next chunk still respects
-          // timeoutMs/signal instead of blocking generateStream() forever.
-          const next = await Promise.race([iterator.next(), guard]);
-          if (next.done) break;
-          const delta = next.value;
-
-          buffer += delta;
-          emit({ type: "delta", text: delta, attempt });
+        for await (const delta of tokenize(source, guard)) {
+          emitter.emit({ type: "delta", text: delta, attempt });
 
           // Incremental per-field validation: the moment a top-level field's
           // JSON closes, check it against its own sub-schema immediately,
-          // instead of waiting for the whole object. Only applies to schemas
-          // that decompose into named fields (Zod object / jsonSchema with
-          // properties) — everything else is a no-op here.
-          const completedFields = extractCompletedTopLevelFields(buffer);
-          for (const [key, raw] of Object.entries(completedFields)) {
-            if (validatedKeys.has(key)) continue;
-            validatedKeys.add(key);
-
-            let value: unknown;
-            try {
-              value = JSON.parse(raw);
-            } catch {
-              continue; // shouldn't happen — the scanner only returns syntactically closed values
-            }
-
+          // instead of waiting for the whole object.
+          for (const { key, value } of parser.feed(delta)) {
             const fieldError = validateFieldIfPossible(schema, key, value, { jsonSchemaValidator });
             if (fieldError) {
-              earlyFailure = new SchemaViolationError(buffer, { field: key, error: fieldError });
+              earlyFailure = new SchemaViolationError(parser.text, { field: key, error: fieldError });
               break;
             }
 
             partialValue[key] = value;
-            emit({ type: "partial", value: { ...partialValue } as Partial<T>, attempt });
+            emitter.emit({ type: "partial", value: { ...partialValue } as Partial<T>, attempt });
           }
 
-          if (earlyFailure) break; // stop consuming further deltas — no point streaming a doomed attempt
+          if (earlyFailure) break; // stop consuming further deltas - no point streaming a doomed attempt
         }
       } catch (err) {
         // Transport/network error, a timeout/abort, or a synchronous validation
-        // throw (e.g. a bad XML template) — not a SchemaViolationError, so it
+        // throw (e.g. a bad XML template) - not a SchemaViolationError, so it
         // is never retried.
-        await iterator.return?.().catch(() => {}); // stop the underlying generator cleanly
         cleanup();
-        finish();
+        emitter.finish();
         rejectResult(err);
         return;
       }
       cleanup();
 
       if (earlyFailure) {
-        emit({ type: "attempt-failed", attempt, error: earlyFailure });
+        emitter.emit({ type: "attempt-failed", attempt, error: earlyFailure });
         if (attempt === maxRetries) {
-          finish();
+          emitter.finish();
           rejectResult(new MaxRetriesExceededError(maxRetries));
           return;
         }
@@ -186,25 +118,25 @@ export function generateStream<T>(
       }
 
       try {
-        // extractJson: true is safe unconditionally — for a clean JSON buffer
+        // extractJson: true is safe unconditionally - for a clean JSON buffer
         // the extraction regex matches the whole string (no-op); for a
         // best-effort backend that wraps JSON in prose, it's required.
-        const data = parseAndValidate<T>(buffer, schema, { extractJson: true });
+        const data = parseAndValidate<T>(parser.text, schema, { extractJson: true });
         const metadata: ResultMetadata = { provider, model: modelName, latencyMs: Date.now() - t0 };
         const finalResult: GenerateResult<T> = { data, guaranteeLevel: model.guaranteeLevel, attempts: attempt, metadata };
-        emit({ type: "done", result: finalResult });
-        finish();
+        emitter.emit({ type: "done", result: finalResult });
+        emitter.finish();
         resolveResult(finalResult);
         return;
       } catch (err) {
         if (!(err instanceof SchemaViolationError)) {
-          finish();
+          emitter.finish();
           rejectResult(err);
           return;
         }
-        emit({ type: "attempt-failed", attempt, error: err });
+        emitter.emit({ type: "attempt-failed", attempt, error: err });
         if (attempt === maxRetries) {
-          finish();
+          emitter.finish();
           rejectResult(new MaxRetriesExceededError(maxRetries));
           return;
         }
@@ -214,9 +146,9 @@ export function generateStream<T>(
   }
 
   pump().catch((err) => {
-    finish();
+    emitter.finish();
     rejectResult(err);
   });
 
-  return { textStream: textChannel.iterable, events: eventChannel.iterable, result };
+  return { textStream: emitter.textStream, events: emitter.events, result };
 }

--- a/src/core/streaming/emitter.ts
+++ b/src/core/streaming/emitter.ts
@@ -1,0 +1,79 @@
+import type { StreamEvent } from "../../types.js";
+
+/**
+ * Single-consumer async channel. Each channel is meant to be iterated by at
+ * most one consumer, matching how StreamEmitter's two public views
+ * (textStream/events) are actually used.
+ */
+function createChannel<T>(): { push(item: T): void; end(): void; iterable: AsyncIterable<T> } {
+  const buffer: T[] = [];
+  let ended = false;
+  let waiting: ((result: IteratorResult<T>) => void) | null = null;
+
+  function push(item: T): void {
+    if (ended) return;
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve({ value: item, done: false });
+    } else {
+      buffer.push(item);
+    }
+  }
+
+  function end(): void {
+    if (ended) return;
+    ended = true;
+    if (waiting) {
+      const resolve = waiting;
+      waiting = null;
+      resolve({ value: undefined as unknown as T, done: true });
+    }
+  }
+
+  const iterable: AsyncIterable<T> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<T>> {
+          if (buffer.length > 0) return Promise.resolve({ value: buffer.shift() as T, done: false });
+          if (ended) return Promise.resolve({ value: undefined as unknown as T, done: true });
+          return new Promise((resolve) => {
+            waiting = resolve;
+          });
+        },
+      };
+    },
+  };
+
+  return { push, end, iterable };
+}
+
+/**
+ * Emitter stage: fans a single internal sequence of lifecycle events out
+ * into the two public views `StreamHandle` exposes - a raw text-delta
+ * channel and a structured lifecycle-event channel - fed from the same
+ * underlying `emit()` calls, so `textStream` and `events` always observe the
+ * exact same deltas in the same order.
+ */
+export class StreamEmitter<T> {
+  private textChannel = createChannel<string>();
+  private eventChannel = createChannel<StreamEvent<T>>();
+
+  emit(event: StreamEvent<T>): void {
+    this.eventChannel.push(event);
+    if (event.type === "delta") this.textChannel.push(event.text);
+  }
+
+  finish(): void {
+    this.eventChannel.end();
+    this.textChannel.end();
+  }
+
+  get textStream(): AsyncIterable<string> {
+    return this.textChannel.iterable;
+  }
+
+  get events(): AsyncIterable<StreamEvent<T>> {
+    return this.eventChannel.iterable;
+  }
+}

--- a/src/core/streaming/incremental-parser.ts
+++ b/src/core/streaming/incremental-parser.ts
@@ -1,18 +1,14 @@
-import { z } from "zod";
-import type { JsonSchemaValidator, SchemaInput } from "../types.js";
-import { checkJsonSchema, isXmlInput, isZodSchema } from "./validate.js";
-
 /**
  * Scans a growing JSON buffer for top-level object fields whose value has
  * fully closed syntactically (string/number/bool/null terminated, or a
  * nested object/array's matching bracket reached at depth 0), and returns
- * their raw JSON text. Fields still being written are skipped — they'll show
+ * their raw JSON text. Fields still being written are skipped - they'll show
  * up on a later call once complete. Only understands an object at the root;
  * any other root shape (array, XML, plain string) returns {} immediately,
  * which is the correct "not applicable" result for those schema types.
  *
  * This gives field-level completion boundaries without a full recursive
- * parse — nested content inside a field's value is treated as an opaque
+ * parse - nested content inside a field's value is treated as an opaque
  * blob (validated as a whole once that field closes), not decomposed further.
  */
 export function extractCompletedTopLevelFields(buffer: string): Record<string, string> {
@@ -24,7 +20,7 @@ export function extractCompletedTopLevelFields(buffer: string): Record<string, s
     while (i < n && /\s/.test(buffer[i]!)) i++;
   };
 
-  // Find the first '{' anywhere, not just at position 0 — a best-effort backend
+  // Find the first '{' anywhere, not just at position 0 - a best-effort backend
   // may wrap the object in prose or a ```json fence (the same tolerance the
   // final extractJson step already applies). A stray '{' in unrelated prose
   // is harmless: the very next check requires a '"' key start immediately
@@ -124,7 +120,7 @@ export function extractCompletedTopLevelFields(buffer: string): Record<string, s
       if (!closed) break;
       valueEnd = i;
     } else {
-      // number / true / false / null — needs a terminator to be sure it's
+      // number / true / false / null - needs a terminator to be sure it's
       // not still growing (e.g. "3" could still become "30").
       while (i < n && !/[,}\s]/.test(buffer[i]!)) i++;
       if (i >= n) break;
@@ -138,50 +134,49 @@ export function extractCompletedTopLevelFields(buffer: string): Record<string, s
       i++;
       continue;
     }
-    break; // "}" (object done) or anything else — stop scanning this pass
+    break; // "}" (object done) or anything else - stop scanning this pass
   }
 
   return result;
 }
 
+export interface CompletedField {
+  key: string;
+  value: unknown;
+}
+
 /**
- * Validates one field's value against its own sub-schema, if the root
- * schema decomposes into named fields (Zod object, or jsonSchema with
- * `properties`). Returns an error message on failure, or null if the field
- * passed (or there's no sub-schema for it / for this schema type at all —
- * XML, pattern, and custom-validator schemas never decompose).
+ * Incremental Parser stage: accumulates raw text deltas from the tokenizer
+ * and surfaces each newly-closed top-level field exactly once, already
+ * parsed to a JS value. One instance per stream attempt - a fresh instance
+ * is created for each retry, so a field seen on a failed attempt is not
+ * treated as "already seen" on the next.
  */
-export function validateFieldIfPossible<T>(
-  schema: SchemaInput<T>,
-  key: string,
-  value: unknown,
-  opts: { jsonSchemaValidator?: JsonSchemaValidator | undefined } = {}
-): string | null {
-  if (isXmlInput(schema)) return null;
+export class IncrementalParser {
+  private buffer = "";
+  private seenKeys = new Set<string>();
 
-  if (isZodSchema(schema)) {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const shape = (schema as any).shape as Record<string, z.ZodTypeAny> | undefined;
-    const fieldSchema = shape?.[key];
-    if (!fieldSchema) return null;
-    const result = fieldSchema.safeParse(value);
-    return result.success ? null : `Field "${key}" failed schema validation: ${result.error.message}`;
-  }
+  /** Feed the next raw text delta; returns fields that closed for the first time. */
+  feed(delta: string): CompletedField[] {
+    this.buffer += delta;
+    const completed = extractCompletedTopLevelFields(this.buffer);
+    const newlyCompleted: CompletedField[] = [];
 
-  if ("jsonSchema" in (schema as object)) {
-    const properties = (schema as { jsonSchema: Record<string, unknown> }).jsonSchema.properties as
-      | Record<string, Record<string, unknown>>
-      | undefined;
-    const propSchema = properties?.[key];
-    if (!propSchema) return null;
-    try {
-      const validate = opts.jsonSchemaValidator ?? checkJsonSchema;
-      validate(value, propSchema);
-      return null;
-    } catch (err) {
-      return err instanceof Error ? err.message : String(err);
+    for (const [key, raw] of Object.entries(completed)) {
+      if (this.seenKeys.has(key)) continue;
+      this.seenKeys.add(key);
+      try {
+        newlyCompleted.push({ key, value: JSON.parse(raw) });
+      } catch {
+        // shouldn't happen - the scanner only returns syntactically closed values
+      }
     }
+
+    return newlyCompleted;
   }
 
-  return null; // pattern / custom validator schemas — no per-field decomposition
+  /** Full accumulated text so far (all deltas fed, in order). */
+  get text(): string {
+    return this.buffer;
+  }
 }

--- a/src/core/streaming/tokenizer.ts
+++ b/src/core/streaming/tokenizer.ts
@@ -1,0 +1,24 @@
+/**
+ * Tokenizer stage: wraps a backend's raw delta stream with a shared
+ * timeout/abort guard, racing each chunk pull (not the whole stream) so a
+ * hung backend still respects timeoutMs/signal instead of blocking
+ * generateStream() forever.
+ *
+ * Closing this generator early (a consumer `break`/`throw` inside a
+ * `for await`) always calls `return()` on the underlying source iterator via
+ * the `finally` block below, so a backend never keeps producing once nobody
+ * downstream is listening - covers both a transport error and an early
+ * validation-triggered abort the same way.
+ */
+export async function* tokenize(source: AsyncIterable<string>, guard: Promise<never>): AsyncGenerator<string> {
+  const iterator = source[Symbol.asyncIterator]();
+  try {
+    while (true) {
+      const next = await Promise.race([iterator.next(), guard]);
+      if (next.done) return;
+      yield next.value;
+    }
+  } finally {
+    await iterator.return?.().catch(() => {});
+  }
+}

--- a/src/core/streaming/validator.ts
+++ b/src/core/streaming/validator.ts
@@ -1,0 +1,48 @@
+import { z } from "zod";
+import type { JsonSchemaValidator, SchemaInput } from "../../types.js";
+import { checkJsonSchema, isXmlInput, isZodSchema } from "../validate.js";
+
+/**
+ * Validator stage (incremental half): validates one field's value against
+ * its own sub-schema, if the root schema decomposes into named fields (Zod
+ * object, or jsonSchema with `properties`). Returns an error message on
+ * failure, or null if the field passed (or there's no sub-schema for it / for
+ * this schema type at all - XML, pattern, and custom-validator schemas never
+ * decompose). The final whole-buffer check reuses the shared
+ * `parseAndValidate()` in `../parse.js` - that stage applies once per
+ * attempt, this one applies once per completed field.
+ */
+export function validateFieldIfPossible<T>(
+  schema: SchemaInput<T>,
+  key: string,
+  value: unknown,
+  opts: { jsonSchemaValidator?: JsonSchemaValidator | undefined } = {}
+): string | null {
+  if (isXmlInput(schema)) return null;
+
+  if (isZodSchema(schema)) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const shape = (schema as any).shape as Record<string, z.ZodTypeAny> | undefined;
+    const fieldSchema = shape?.[key];
+    if (!fieldSchema) return null;
+    const result = fieldSchema.safeParse(value);
+    return result.success ? null : `Field "${key}" failed schema validation: ${result.error.message}`;
+  }
+
+  if ("jsonSchema" in (schema as object)) {
+    const properties = (schema as { jsonSchema: Record<string, unknown> }).jsonSchema.properties as
+      | Record<string, Record<string, unknown>>
+      | undefined;
+    const propSchema = properties?.[key];
+    if (!propSchema) return null;
+    try {
+      const validate = opts.jsonSchemaValidator ?? checkJsonSchema;
+      validate(value, propSchema);
+      return null;
+    } catch (err) {
+      return err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  return null; // pattern / custom validator schemas - no per-field decomposition
+}

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { JsonSchemaValidator, SchemaInput, XmlInput } from "../types.js";
+import type { ConfidenceScorer, JsonSchemaValidator, PostProcessor, SchemaInput, SemanticValidator, XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
 import { finalizeXmlOutput } from "./xml.js";
 
@@ -117,4 +117,62 @@ export function validateOutput<T>(
   }
 
   throw new Error("Unknown schema type");
+}
+
+export interface ValidationPipelineOptions<T> {
+  jsonSchemaValidator?: JsonSchemaValidator | undefined;
+  semanticValidator?: SemanticValidator<T> | undefined;
+  confidenceScorer?: ConfidenceScorer<T> | undefined;
+  minConfidence?: number | undefined;
+  postProcessors?: PostProcessor<T>[] | undefined;
+}
+
+export interface ValidationPipelineResult<T> {
+  data: T;
+  confidence?: number;
+}
+
+/**
+ * `parse → structural validation → semantic validation → confidence scoring
+ * → post-processors → return`. Structural validation (`validateOutput`
+ * above) is the only required stage — every other stage runs only if the
+ * caller supplied it, and a stage failure throws `SchemaViolationError` so
+ * `generate()`'s retry loop treats it exactly like a structural failure.
+ * Post-processors run last and are never retried — they only reshape a
+ * value that already passed every check.
+ */
+export async function runValidationPipeline<T>(
+  output: unknown,
+  schema: SchemaInput<T>,
+  prompt: string,
+  opts: ValidationPipelineOptions<T> = {}
+): Promise<ValidationPipelineResult<T>> {
+  let data = validateOutput<T>(output, schema, { jsonSchemaValidator: opts.jsonSchemaValidator });
+
+  if (opts.semanticValidator) {
+    try {
+      await opts.semanticValidator(data, { prompt });
+    } catch (err) {
+      throw new SchemaViolationError(JSON.stringify(data), err);
+    }
+  }
+
+  let confidence: number | undefined;
+  if (opts.confidenceScorer) {
+    confidence = await opts.confidenceScorer(data, { prompt });
+    if (opts.minConfidence !== undefined && confidence < opts.minConfidence) {
+      throw new SchemaViolationError(
+        JSON.stringify(data),
+        `Confidence score ${confidence} is below minConfidence ${opts.minConfidence}`
+      );
+    }
+  }
+
+  if (opts.postProcessors) {
+    for (const postProcess of opts.postProcessors) {
+      data = await postProcess(data, confidence === undefined ? { prompt } : { prompt, confidence });
+    }
+  }
+
+  return confidence === undefined ? { data } : { data, confidence };
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ export { xmlType, validateXmlTemplate } from "./core/xml.js";
 export { createConversationMemory, COMPLETION_SENTINEL } from "./core/turnaround.js";
 export { createClient } from "./core/client.js";
 export { composeMiddleware, loggingMiddleware } from "./core/middleware.js";
-export { checkJsonSchema } from "./core/validate.js";
+export { checkJsonSchema, runValidationPipeline } from "./core/validate.js";
 
 export * from "./backends/index.js";
 
@@ -19,6 +19,9 @@ export type {
   GenerateResult,
   ResultMetadata,
   JsonSchemaValidator,
+  SemanticValidator,
+  ConfidenceScorer,
+  PostProcessor,
   GuaranteeLevel,
   XmlInput,
   ChatMessage,
@@ -34,5 +37,6 @@ export type {
 
 export type { CreateClientOptions, ShapecraftClient } from "./core/client.js";
 export type { Middleware, MiddlewareContext, NextFn } from "./core/middleware.js";
+export type { ValidationPipelineOptions, ValidationPipelineResult } from "./core/validate.js";
 
 export { SchemaViolationError, MaxRetriesExceededError, MaxTurnsExceededError, TimeoutError } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,31 @@ export interface ShapecraftModel {
  */
 export type JsonSchemaValidator = (value: unknown, schema: Record<string, unknown>) => void;
 
+/**
+ * Content/meaning check that runs after structural validation passes — e.g.
+ * "does this value actually appear in the source text" checks that no
+ * type/shape check can catch. Throw (sync or async) to fail the stage; the
+ * failure is wrapped in a `SchemaViolationError` so it retries exactly like a
+ * structural failure does.
+ */
+export type SemanticValidator<T = unknown> = (value: T, context: { prompt: string }) => void | Promise<void>;
+
+/**
+ * Assigns a 0-1 confidence score to an already-validated value. Purely
+ * informational unless `minConfidence` is also set, in which case a score
+ * below the threshold fails the stage (wrapped in `SchemaViolationError`,
+ * same retry treatment as structural/semantic failures).
+ */
+export type ConfidenceScorer<T = unknown> = (value: T, context: { prompt: string }) => number | Promise<number>;
+
+/**
+ * Transforms an already-validated value (e.g. normalization, trimming,
+ * enrichment). Runs last, in array order, after every validation/scoring
+ * stage has passed — a post-processor is never retried, it only reshapes a
+ * value that already satisfied the schema.
+ */
+export type PostProcessor<T = unknown> = (value: T, context: { prompt: string; confidence?: number }) => T | Promise<T>;
+
 export interface GenerateOptions {
   maxRetries?: number;
   systemPrompt?: string;
@@ -119,6 +144,18 @@ export interface GenerateOptions {
    * callers see no behavior change.
    */
   jsonSchemaValidator?: JsonSchemaValidator;
+  /** Optional stage after structural validation passes — see `SemanticValidator`. */
+  semanticValidator?: SemanticValidator<unknown>;
+  /** Optional stage after semantic validation passes — see `ConfidenceScorer`. */
+  confidenceScorer?: ConfidenceScorer<unknown>;
+  /**
+   * Minimum acceptable `confidenceScorer` score (0-1). Ignored if no
+   * `confidenceScorer` is set. A score below this fails the attempt and
+   * triggers a retry, same as a structural/semantic validation failure.
+   */
+  minConfidence?: number;
+  /** Optional final stage — see `PostProcessor`. Runs in array order. */
+  postProcessors?: PostProcessor<unknown>[];
 }
 
 /** Best-effort call metadata — always present, but only `provider`/`model`/
@@ -139,6 +176,8 @@ export interface GenerateResult<T> {
   guaranteeLevel: GuaranteeLevel;
   attempts: number;
   metadata: ResultMetadata;
+  /** Present only when a `confidenceScorer` was supplied — see `ConfidenceScorer`. */
+  confidence?: number;
 }
 
 /** One independent unit of work for `generateBatch()`/`client.generateBatch()`. */

--- a/tests/hardening.test.ts
+++ b/tests/hardening.test.ts
@@ -346,3 +346,101 @@ describe("jsonSchemaValidator (pluggable)", () => {
     await expect(stream.result).rejects.toBeInstanceOf(MaxRetriesExceededError);
   });
 });
+
+// ─── 7.8 Staged validation pipeline ────────────────────────────────────────────
+
+describe("staged validation pipeline (semanticValidator / confidenceScorer / postProcessors)", () => {
+  const schema = z.object({ name: z.string() });
+
+  it("no optional stages configured: behavior is unchanged (regression)", async () => {
+    const model = mockModel({ name: "Alice" });
+    const result = await generate(model, schema, "x");
+    expect(result.data).toEqual({ name: "Alice" });
+    expect(result.confidence).toBeUndefined();
+  });
+
+  it("semanticValidator runs after structural validation passes, receives the parsed value and prompt", async () => {
+    const model = mockModel({ name: "Alice" });
+    let seen: unknown;
+    await generate(model, schema, "the prompt", {
+      semanticValidator: (value, ctx) => {
+        seen = { value, prompt: ctx.prompt };
+      },
+    });
+    expect(seen).toEqual({ value: { name: "Alice" }, prompt: "the prompt" });
+  });
+
+  it("a throwing semanticValidator fails the attempt like a structural failure and retries", async () => {
+    let calls = 0;
+    const model = mockModel({ name: "Alice" });
+    await expect(
+      generate(model, schema, "x", {
+        maxRetries: 2,
+        semanticValidator: () => {
+          calls++;
+          throw new Error("no supporting evidence in source");
+        },
+      })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+    expect(calls).toBe(2);
+  });
+
+  it("confidenceScorer's score is exposed on the result", async () => {
+    const model = mockModel({ name: "Alice" });
+    const result = await generate(model, schema, "x", {
+      confidenceScorer: (value) => ((value as { name: string }).name === "Alice" ? 0.9 : 0.1),
+    });
+    expect(result.confidence).toBe(0.9);
+  });
+
+  it("minConfidence below the scored value fails the attempt and retries", async () => {
+    let calls = 0;
+    const model = mockModel({ name: "Alice" });
+    await expect(
+      generate(model, schema, "x", {
+        maxRetries: 2,
+        confidenceScorer: () => {
+          calls++;
+          return 0.2;
+        },
+        minConfidence: 0.5,
+      })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+    expect(calls).toBe(2);
+  });
+
+  it("postProcessors run in array order after every validation/scoring stage passes", async () => {
+    const model = mockModel({ name: "alice" });
+    const result = await generate(model, schema, "x", {
+      postProcessors: [
+        (value) => ({ ...(value as { name: string }), name: (value as { name: string }).name.toUpperCase() }),
+        (value) => ({ ...(value as { name: string }), name: `${(value as { name: string }).name}!` }),
+      ],
+    });
+    expect(result.data).toEqual({ name: "ALICE!" });
+  });
+
+  it("postProcessors receive the confidence score from the previous stage", async () => {
+    const model = mockModel({ name: "Alice" });
+    let seenConfidence: number | undefined;
+    await generate(model, schema, "x", {
+      confidenceScorer: () => 0.75,
+      postProcessors: [
+        (value, ctx) => {
+          seenConfidence = ctx.confidence;
+          return value;
+        },
+      ],
+    });
+    expect(seenConfidence).toBe(0.75);
+  });
+
+  it("client-level defaults for the new stages apply, and a per-call option overrides them", async () => {
+    const model = mockModel({ name: "Alice" });
+    const client = createClient({ confidenceScorer: () => 0.4, minConfidence: 0.5 });
+    await expect(client.generate(model, schema, "x", { maxRetries: 1 })).rejects.toBeInstanceOf(MaxRetriesExceededError);
+
+    const result = await client.generate(model, schema, "x", { confidenceScorer: () => 0.9 });
+    expect(result.confidence).toBe(0.9);
+  });
+});

--- a/tests/streaming-stages.test.ts
+++ b/tests/streaming-stages.test.ts
@@ -1,0 +1,202 @@
+import { describe, it, expect } from "vitest";
+import { z } from "zod";
+import { tokenize } from "../src/core/streaming/tokenizer.js";
+import { extractCompletedTopLevelFields, IncrementalParser } from "../src/core/streaming/incremental-parser.js";
+import { validateFieldIfPossible } from "../src/core/streaming/validator.js";
+import { StreamEmitter } from "../src/core/streaming/emitter.js";
+import type { StreamEvent } from "../src/types.js";
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+function neverResolvingGuard(): Promise<never> {
+  return new Promise<never>(() => {});
+}
+
+/** An async iterable that records whether return() was ever invoked. */
+function trackedSource(chunks: string[]): { source: AsyncIterable<string>; returned: () => boolean } {
+  let returned = false;
+  let i = 0;
+  const source: AsyncIterable<string> = {
+    [Symbol.asyncIterator]() {
+      return {
+        next(): Promise<IteratorResult<string>> {
+          if (i >= chunks.length) return Promise.resolve({ value: undefined, done: true });
+          return Promise.resolve({ value: chunks[i++]!, done: false });
+        },
+        return(): Promise<IteratorResult<string>> {
+          returned = true;
+          return Promise.resolve({ value: undefined, done: true });
+        },
+      };
+    },
+  };
+  return { source, returned: () => returned };
+}
+
+describe("tokenize (Tokenizer stage)", () => {
+  it("yields every chunk from the source in order", async () => {
+    const { source } = trackedSource(["a", "b", "c"]);
+    const out = await collect(tokenize(source, neverResolvingGuard()));
+    expect(out).toEqual(["a", "b", "c"]);
+  });
+
+  it("propagates a guard rejection (timeout/abort) instead of waiting on a hung source", async () => {
+    const hungSource: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        return { next: () => new Promise(() => {}) }; // never resolves
+      },
+    };
+    const guard = Promise.reject(new Error("timed out"));
+    await expect(collect(tokenize(hungSource, guard))).rejects.toThrow("timed out");
+  });
+
+  it("calls return() on the underlying source when the consumer stops early", async () => {
+    const { source, returned } = trackedSource(["a", "b", "c"]);
+    const out: string[] = [];
+    for await (const chunk of tokenize(source, neverResolvingGuard())) {
+      out.push(chunk);
+      if (chunk === "a") break;
+    }
+    expect(out).toEqual(["a"]);
+    expect(returned()).toBe(true);
+  });
+
+  it("calls return() on the underlying source when the source itself errors mid-stream", async () => {
+    let returned = false;
+    const source: AsyncIterable<string> = {
+      [Symbol.asyncIterator]() {
+        let i = 0;
+        return {
+          next(): Promise<IteratorResult<string>> {
+            if (i === 0) {
+              i++;
+              return Promise.resolve({ value: "a", done: false });
+            }
+            return Promise.reject(new Error("network failure"));
+          },
+          return(): Promise<IteratorResult<string>> {
+            returned = true;
+            return Promise.resolve({ value: undefined, done: true });
+          },
+        };
+      },
+    };
+    await expect(collect(tokenize(source, neverResolvingGuard()))).rejects.toThrow("network failure");
+    expect(returned).toBe(true);
+  });
+});
+
+describe("extractCompletedTopLevelFields (pure scanner)", () => {
+  it("returns {} for a buffer with no top-level object", () => {
+    expect(extractCompletedTopLevelFields("not json at all")).toEqual({});
+  });
+
+  it("returns only fields that have fully closed", () => {
+    expect(extractCompletedTopLevelFields('{"name":"Alice","age":3')).toEqual({ name: '"Alice"' });
+  });
+});
+
+describe("IncrementalParser (Incremental Parser stage)", () => {
+  it("surfaces each field exactly once across multiple feed() calls", () => {
+    const parser = new IncrementalParser();
+    const first = parser.feed('{"name":"Alice",');
+    expect(first).toEqual([{ key: "name", value: "Alice" }]);
+
+    const second = parser.feed('"age":30}');
+    expect(second).toEqual([{ key: "age", value: 30 }]);
+
+    // Feeding more of the same buffer again must not re-surface "name" or "age".
+    const third = parser.feed("");
+    expect(third).toEqual([]);
+  });
+
+  it("accumulates the full text across feeds via .text", () => {
+    const parser = new IncrementalParser();
+    parser.feed('{"a":1,');
+    parser.feed('"b":2}');
+    expect(parser.text).toBe('{"a":1,"b":2}');
+  });
+
+  it("is independent per instance - state does not leak across attempts", () => {
+    const attempt1 = new IncrementalParser();
+    attempt1.feed('{"name":"Alice"}');
+
+    const attempt2 = new IncrementalParser();
+    const fields = attempt2.feed('{"name":"Bob"}');
+    expect(fields).toEqual([{ key: "name", value: "Bob" }]);
+  });
+});
+
+describe("validateFieldIfPossible (Validator stage)", () => {
+  const PersonSchema = z.object({ name: z.string(), age: z.number() });
+
+  it("passes a valid field against a Zod schema", () => {
+    expect(validateFieldIfPossible(PersonSchema, "age", 30)).toBeNull();
+  });
+
+  it("rejects an invalid field against a Zod schema", () => {
+    expect(validateFieldIfPossible(PersonSchema, "age", "not-a-number")).toMatch(/age/);
+  });
+
+  it("passes a valid field against a jsonSchema properties entry", () => {
+    const schema = { jsonSchema: { type: "object", properties: { age: { type: "number" } } } };
+    expect(validateFieldIfPossible(schema, "age", 30)).toBeNull();
+  });
+
+  it("rejects an invalid field against a jsonSchema properties entry", () => {
+    const schema = { jsonSchema: { type: "object", properties: { age: { type: "number" } } } };
+    expect(validateFieldIfPossible(schema, "age", "thirty")).not.toBeNull();
+  });
+
+  it("never decomposes XML schemas - always returns null", () => {
+    const schema = { xml: { template: "<book>{string}</book>" } };
+    expect(validateFieldIfPossible(schema, "anything", "value")).toBeNull();
+  });
+
+  it("never decomposes pattern schemas - always returns null", () => {
+    const schema = { pattern: /^\d+$/ };
+    expect(validateFieldIfPossible(schema, "anything", "value")).toBeNull();
+  });
+});
+
+describe("StreamEmitter (Emitter stage)", () => {
+  it("fans a delta event out to both textStream and events, in the same order", async () => {
+    const emitter = new StreamEmitter<{ name: string }>();
+    emitter.emit({ type: "attempt-start", attempt: 1 });
+    emitter.emit({ type: "delta", text: "hello", attempt: 1 });
+    emitter.emit({ type: "delta", text: " world", attempt: 1 });
+    emitter.finish();
+
+    const [textParts, events] = await Promise.all([collect(emitter.textStream), collect(emitter.events)]);
+
+    expect(textParts).toEqual(["hello", " world"]);
+    expect(events.map((e) => e.type)).toEqual(["attempt-start", "delta", "delta"]);
+  });
+
+  it("non-delta events never reach textStream", async () => {
+    const emitter = new StreamEmitter<{ name: string }>();
+    const doneEvent: StreamEvent<{ name: string }> = {
+      type: "done",
+      result: { data: { name: "Alice" }, guaranteeLevel: "constrained", attempts: 1, metadata: { provider: "mock", model: "m", latencyMs: 1 } },
+    };
+    emitter.emit(doneEvent);
+    emitter.finish();
+
+    const textParts = await collect(emitter.textStream);
+    expect(textParts).toEqual([]);
+  });
+
+  it("finish() ends both channels so pending consumers resolve with done", async () => {
+    const emitter = new StreamEmitter<{ name: string }>();
+    const textPromise = collect(emitter.textStream);
+    const eventsPromise = collect(emitter.events);
+    emitter.finish();
+
+    await expect(textPromise).resolves.toEqual([]);
+    await expect(eventsPromise).resolves.toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

- Replaces the monolithic `pump()` in `stream.ts` with four independently testable stages: `tokenizer.ts` (wraps the backend's raw delta stream with the shared timeout/abort guard), `incremental-parser.ts`, `validator.ts`, and `emitter.ts` (turns parser/validator output into `StreamEvent`s). Purely a structural extraction - streaming behavior is unchanged.
- Adds a staged validation pipeline to `generate()`: `parse -> structural validation -> semantic validation -> confidence scoring -> post-processors -> return`. Structural validation stays the only required stage.
- New optional `GenerateOptions` fields: `semanticValidator` (content/grounding check, throws to fail and retries like a structural failure), `confidenceScorer` (returns a 0-1 score exposed as `result.confidence`), `minConfidence` (fails and retries if the score is below threshold), and `postProcessors` (array run last, reshaping an already-validated value - never retried).
- All four new options are also settable as `createClient()` defaults, following the same per-call-overrides-client-default pattern as `jsonSchemaValidator`.
- Wired into `generate()` only - `generateStream()`'s per-field incremental validation is untouched, still just `checkJsonSchema`/custom `jsonSchemaValidator`.
- Removes a stale CHANGELOG note referencing internal fork branches that never existed on the upstream repo.
- Bumps version to 2.0.4.

## Test plan
- [x] New `tests/streaming-stages.test.ts` covers each streaming stage in isolation
- [x] New tests in `tests/hardening.test.ts` cover `semanticValidator`, `confidenceScorer`/`minConfidence`, `postProcessors`, and client-level defaults for all three
- [x] Full test suite passes (only pre-existing failures are real-API OpenAI quota errors, unrelated to this change)
- [x] Typecheck passes