### PR TITLE
feat: add FHIR R4 preset schemas via @aviasole/shapecraft/fhir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [2.1.0] - 2026-07-10
+
+### Added
+
+- FHIR R4 preset schemas via `@aviasole/shapecraft/fhir` entrypoint - Patient, Observation,
+  Condition, MedicationRequest, Encounter. Each is a ready-to-use `SchemaInput` with a typed
+  result interface, so it works with `generate()`/`generateStream()` unchanged.
+
 ## [2.0.4] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -280,6 +280,30 @@ for await (const event of stream2.events) {
 
 **Streaming smoothness tracks guarantee level.** `native`/`constrained` backends (OpenAI, Groq, Ollama) rarely fail validation — the server already constrains tokens as they're generated — so streams almost never restart. `best-effort` (Anthropic) has no such constraint, so a stream may visibly restart more often.
 
+## FHIR presets
+
+Ready-made FHIR R4 resource schemas for healthcare extraction, behind a separate (tree-shakeable) entrypoint. Each preset is an ordinary schema input, so it works with `generate()` and `generateStream()` unchanged — you get a typed, structurally-validated resource back.
+
+```typescript
+import { generate } from "@aviasole/shapecraft";
+import { fhir } from "@aviasole/shapecraft/fhir";
+
+const { data } = await generate(
+  model,
+  fhir.Patient,
+  "John Doe, 35-year-old male, date of birth 1990-02-11."
+);
+// data: Patient  — { resourceType: "Patient", name: [{ family: "Doe", given: ["John"] }],
+//                    gender: "male", birthDate: "1990-02-11" }
+```
+
+Five R4 resources are included: **`Patient`**, **`Observation`**, **`Condition`**, **`MedicationRequest`**, **`Encounter`**. Each models a practical common subset (not every field the spec allows) and enforces the required-bound value-set enums (`gender`, `status`, `intent`, …). Because they're JSON-object schemas, streaming `partial` events validate each top-level field as it arrives, for free.
+
+Two things worth knowing before you rely on them:
+
+- **`required` is opinionated, not FHIR cardinality.** FHIR marks almost nothing mandatory (a `Patient` with no name is technically valid FHIR). These presets require a *useful* minimum for extraction (e.g. `Patient` requires name + gender + birthDate). Where FHIR genuinely mandates a field (`Observation.status`/`code`, `MedicationRequest.status`/`intent`/`subject`), that's mirrored exactly.
+- **Structural, not clinical.** A preset guarantees the resource is well-formed and required-fields-complete. It does **not** verify terminology codes (LOINC/SNOMED/RxNorm membership is not checked — a `Coding` is validated as having `system`/`code` strings, not as a real code), date formats, choice-type polymorphism (each preset commits to one `value[x]`/`medication[x]` variant), or any clinical invariant. **A structurally-valid FHIR resource is not the same as a correct or safe-to-act-on one** — see the guarantees note directly below.
+
 ## What shapecraft guarantees — and what it doesn't
 
 Every mechanism above (`native`, `constrained`, `best-effort` + retry) targets one thing: **the output is structurally valid** — it parses, the types match, required fields are present and non-empty. That's a real, load-bearing guarantee: it's the difference between code that can trust `result.data.age` is a `number` versus code that has to defensively re-check everything the model says.

--- a/examples/fhir.ts
+++ b/examples/fhir.ts
@@ -1,0 +1,41 @@
+/**
+ * Example: FHIR R4 preset schemas.
+ *
+ * `fhir.Patient` etc. are ordinary { jsonSchema } SchemaInputs, so they work
+ * with generate() and generateStream() with no special handling — you get a
+ * typed, structurally-validated FHIR resource back.
+ *
+ * shapecraft guarantees the resource is STRUCTURALLY well-formed (required
+ * fields present, value-set enums like `gender`/`status` respected, types
+ * correct). It does NOT verify clinical correctness or terminology codes
+ * (LOINC/SNOMED membership is not checked). See the README "FHIR presets" note.
+ */
+import { generate, generateStream, anthropic } from "@aviasole/shapecraft";
+import { fhir } from "@aviasole/shapecraft/fhir";
+
+const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+
+// ── One-shot: extract a Patient from a clinical sentence ────────────────────
+const { data: patient } = await generate(
+  model,
+  fhir.Patient,
+  "John Doe, 35-year-old male, date of birth 1990-02-11, lives in Boston."
+);
+console.log(patient);
+// { resourceType: "Patient", name: [{ family: "Doe", given: ["John"] }],
+//   gender: "male", birthDate: "1990-02-11", address: [{ city: "Boston" }] }
+
+// ── Streaming: an Observation, with per-field partial validation ────────────
+const stream = generateStream(
+  model,
+  fhir.Observation,
+  "Blood pressure reading of 120 mmHg, status final, taken 2024-01-10."
+);
+
+for await (const event of stream.events) {
+  if (event.type === "partial") console.log("field ready:", event.value);
+}
+const { data: observation } = await stream.result;
+console.log(observation);
+// { resourceType: "Observation", status: "final",
+//   code: { text: "Blood pressure" }, valueQuantity: { value: 120, unit: "mmHg" } }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,11 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
+    },
+    "./fhir": {
+      "types": "./dist/fhir/index.d.ts",
+      "import": "./dist/fhir/index.js",
+      "require": "./dist/fhir/index.cjs"
     }
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.4",
+  "version": "2.1.0",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { SchemaInput, XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
-import { finalizeXmlOutput } from "./xml.js";
+import { finalizeXmlOutput, isNonEmpty } from "./xml.js";
 
 export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
   return schema instanceof z.ZodType;
@@ -45,6 +45,10 @@ export function checkJsonSchema(value: unknown, schema: Record<string, unknown>)
 
     for (const key of required) {
       if (!(key in obj)) throw new Error(`Missing required property: "${key}"`);
+      // "required" means present AND non-empty — same as the XML path. Stops a
+      // constrained grammar from satisfying a required field with "" / [] / {}
+      // when the source had no value for it.
+      if (!isNonEmpty(obj[key])) throw new Error(`Required property is empty: "${key}"`);
     }
 
     for (const [key, propSchema] of Object.entries(properties)) {

--- a/src/core/xml.ts
+++ b/src/core/xml.ts
@@ -181,7 +181,12 @@ export function buildXmlFromTree(tree: Record<string, unknown>): string {
 
 // ─── Required-node validation ─────────────────────────────────────────────────
 
-function isNonEmpty(value: unknown): boolean {
+/**
+ * True if a value counts as "present and non-empty" for a required field.
+ * Shared by the XML required-node check and the JSON Schema required check so
+ * both schema paths agree on what "required" means. `0` / `false` stay valid.
+ */
+export function isNonEmpty(value: unknown): boolean {
   if (value === null || value === undefined) return false;
   if (typeof value === "string") return value.trim().length > 0;
   if (Array.isArray(value)) return value.length > 0 && value.some(isNonEmpty);

--- a/src/fhir/condition.ts
+++ b/src/fhir/condition.ts
@@ -1,0 +1,44 @@
+import type { SchemaInput } from "../types.js";
+import {
+  codeableConceptSchema,
+  referenceSchema,
+  type CodeableConcept,
+  type Reference,
+} from "./types.js";
+
+/**
+ * FHIR R4 Condition (a diagnosis / problem — common subset).
+ *
+ * `subject` is mandatory (1..1) in FHIR. `clinicalStatus` / `verificationStatus`
+ * are bound value sets, but in R4 they are CodeableConcept-shaped (the code sits
+ * at coding[].code), so this preset validates their STRUCTURE, not the inner
+ * code membership. `code` here is the actual diagnosis. See
+ * fhir-support-plan.md §5–6.
+ */
+export interface Condition {
+  resourceType: "Condition";
+  clinicalStatus?: CodeableConcept;
+  verificationStatus?: CodeableConcept;
+  category?: CodeableConcept[];
+  code: CodeableConcept;
+  subject: Reference;
+  onsetDateTime?: string;
+  recordedDate?: string;
+}
+
+const ConditionJsonSchema = {
+  type: "object",
+  required: ["resourceType", "code", "subject"],
+  properties: {
+    resourceType: { type: "string", enum: ["Condition"] },
+    clinicalStatus: codeableConceptSchema,
+    verificationStatus: codeableConceptSchema,
+    category: { type: "array", items: codeableConceptSchema },
+    code: codeableConceptSchema,
+    subject: referenceSchema,
+    onsetDateTime: { type: "string" },
+    recordedDate: { type: "string" },
+  },
+};
+
+export const Condition: SchemaInput<Condition> = { jsonSchema: ConditionJsonSchema };

--- a/src/fhir/encounter.ts
+++ b/src/fhir/encounter.ts
@@ -1,0 +1,66 @@
+import type { SchemaInput } from "../types.js";
+import {
+  codeableConceptSchema,
+  codingSchema,
+  periodSchema,
+  referenceSchema,
+  type CodeableConcept,
+  type Coding,
+  type Period,
+  type Reference,
+} from "./types.js";
+
+/**
+ * FHIR R4 Encounter (a visit / admission — common subset).
+ *
+ * `status` and `class` are mandatory (1..1) in R4. `class` is a single Coding
+ * (v2 ActEncounterCode: AMB ambulatory, IMP inpatient, EMER emergency, …), not
+ * a CodeableConcept — modeled as such here. See fhir-support-plan.md §5.
+ */
+export interface Encounter {
+  resourceType: "Encounter";
+  status:
+    | "planned"
+    | "arrived"
+    | "triaged"
+    | "in-progress"
+    | "onleave"
+    | "finished"
+    | "cancelled"
+    | "entered-in-error"
+    | "unknown";
+  class: Coding;
+  type?: CodeableConcept[];
+  subject?: Reference;
+  period?: Period;
+  reasonCode?: CodeableConcept[];
+}
+
+const EncounterJsonSchema = {
+  type: "object",
+  required: ["resourceType", "status", "class"],
+  properties: {
+    resourceType: { type: "string", enum: ["Encounter"] },
+    status: {
+      type: "string",
+      enum: [
+        "planned",
+        "arrived",
+        "triaged",
+        "in-progress",
+        "onleave",
+        "finished",
+        "cancelled",
+        "entered-in-error",
+        "unknown",
+      ],
+    },
+    class: codingSchema,
+    type: { type: "array", items: codeableConceptSchema },
+    subject: referenceSchema,
+    period: periodSchema,
+    reasonCode: { type: "array", items: codeableConceptSchema },
+  },
+};
+
+export const Encounter: SchemaInput<Encounter> = { jsonSchema: EncounterJsonSchema };

--- a/src/fhir/index.ts
+++ b/src/fhir/index.ts
@@ -1,0 +1,44 @@
+/**
+ * FHIR R4 preset schemas — a separate, tree-shakeable entrypoint.
+ *
+ *   import { fhir } from "@aviasole/shapecraft/fhir";
+ *   import { generate } from "@aviasole/shapecraft";
+ *
+ *   const { data } = await generate(model, fhir.Patient, clinicalNote);
+ *
+ * Each preset is an ordinary `{ jsonSchema }` SchemaInput, so it flows through
+ * generate() / generateStream() with zero special-casing. shapecraft guarantees
+ * these resources are STRUCTURALLY well-formed and required-fields-complete; it
+ * does not and cannot guarantee they are clinically correct. See
+ * fhir-support-plan.md §6.
+ */
+import { Patient } from "./patient.js";
+import { Observation } from "./observation.js";
+import { Condition } from "./condition.js";
+import { MedicationRequest } from "./medication-request.js";
+import { Encounter } from "./encounter.js";
+
+export const fhir = {
+  Patient,
+  Observation,
+  Condition,
+  MedicationRequest,
+  Encounter,
+} as const;
+
+export type { Patient } from "./patient.js";
+export type { Observation } from "./observation.js";
+export type { Condition } from "./condition.js";
+export type { MedicationRequest } from "./medication-request.js";
+export type { Encounter } from "./encounter.js";
+export type {
+  Coding,
+  CodeableConcept,
+  Reference,
+  HumanName,
+  ContactPoint,
+  Address,
+  Period,
+  Quantity,
+  Identifier,
+} from "./types.js";

--- a/src/fhir/medication-request.ts
+++ b/src/fhir/medication-request.ts
@@ -1,0 +1,91 @@
+import type { SchemaInput } from "../types.js";
+import {
+  codeableConceptSchema,
+  referenceSchema,
+  type CodeableConcept,
+  type Reference,
+} from "./types.js";
+
+/**
+ * FHIR R4 MedicationRequest (a prescription — common subset).
+ *
+ * `status`, `intent`, `subject` are mandatory (1..1) in FHIR. The medication is
+ * a CHOICE type (`medication[x]`); this preset commits to
+ * `medicationCodeableConcept` (coded drug) and does not model
+ * `medicationReference`. See fhir-support-plan.md §6.
+ */
+export interface MedicationRequest {
+  resourceType: "MedicationRequest";
+  status:
+    | "active"
+    | "on-hold"
+    | "cancelled"
+    | "completed"
+    | "entered-in-error"
+    | "stopped"
+    | "draft"
+    | "unknown";
+  intent:
+    | "proposal"
+    | "plan"
+    | "order"
+    | "original-order"
+    | "reflex-order"
+    | "filler-order"
+    | "instance-order"
+    | "option";
+  medicationCodeableConcept: CodeableConcept;
+  subject: Reference;
+  authoredOn?: string;
+  requester?: Reference;
+  dosageInstruction?: { text?: string }[];
+}
+
+const MedicationRequestJsonSchema = {
+  type: "object",
+  required: ["resourceType", "status", "intent", "medicationCodeableConcept", "subject"],
+  properties: {
+    resourceType: { type: "string", enum: ["MedicationRequest"] },
+    status: {
+      type: "string",
+      enum: [
+        "active",
+        "on-hold",
+        "cancelled",
+        "completed",
+        "entered-in-error",
+        "stopped",
+        "draft",
+        "unknown",
+      ],
+    },
+    intent: {
+      type: "string",
+      enum: [
+        "proposal",
+        "plan",
+        "order",
+        "original-order",
+        "reflex-order",
+        "filler-order",
+        "instance-order",
+        "option",
+      ],
+    },
+    medicationCodeableConcept: codeableConceptSchema,
+    subject: referenceSchema,
+    authoredOn: { type: "string" },
+    requester: referenceSchema,
+    dosageInstruction: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { text: { type: "string" } },
+      },
+    },
+  },
+};
+
+export const MedicationRequest: SchemaInput<MedicationRequest> = {
+  jsonSchema: MedicationRequestJsonSchema,
+};

--- a/src/fhir/observation.ts
+++ b/src/fhir/observation.ts
@@ -1,0 +1,64 @@
+import type { SchemaInput } from "../types.js";
+import {
+  codeableConceptSchema,
+  quantitySchema,
+  referenceSchema,
+  type CodeableConcept,
+  type Quantity,
+  type Reference,
+} from "./types.js";
+
+/**
+ * FHIR R4 Observation (common subset).
+ *
+ * `status` and `code` ARE mandatory (1..1) in FHIR, so they are required here
+ * for real. The value is a CHOICE type in FHIR (`value[x]`); this preset commits
+ * to `valueQuantity` — the numeric-measurement form — and does not model
+ * valueString / valueCodeableConcept / component observations. See
+ * fhir-support-plan.md §6.
+ */
+export interface Observation {
+  resourceType: "Observation";
+  status:
+    | "registered"
+    | "preliminary"
+    | "final"
+    | "amended"
+    | "corrected"
+    | "cancelled"
+    | "entered-in-error"
+    | "unknown";
+  category?: CodeableConcept[];
+  code: CodeableConcept;
+  subject?: Reference;
+  effectiveDateTime?: string;
+  valueQuantity?: Quantity;
+}
+
+const ObservationJsonSchema = {
+  type: "object",
+  required: ["resourceType", "status", "code"],
+  properties: {
+    resourceType: { type: "string", enum: ["Observation"] },
+    status: {
+      type: "string",
+      enum: [
+        "registered",
+        "preliminary",
+        "final",
+        "amended",
+        "corrected",
+        "cancelled",
+        "entered-in-error",
+        "unknown",
+      ],
+    },
+    category: { type: "array", items: codeableConceptSchema },
+    code: codeableConceptSchema,
+    subject: referenceSchema,
+    effectiveDateTime: { type: "string" },
+    valueQuantity: quantitySchema,
+  },
+};
+
+export const Observation: SchemaInput<Observation> = { jsonSchema: ObservationJsonSchema };

--- a/src/fhir/patient.ts
+++ b/src/fhir/patient.ts
@@ -1,0 +1,50 @@
+import type { SchemaInput } from "../types.js";
+import {
+  addressSchema,
+  contactPointSchema,
+  humanNameSchema,
+  identifierSchema,
+  type Address,
+  type ContactPoint,
+  type HumanName,
+  type Identifier,
+} from "./types.js";
+
+/**
+ * FHIR R4 Patient (common subset).
+ *
+ * NOTE on `required`: FHIR itself marks NO Patient field as mandatory (1..1).
+ * This preset's required set (name, gender, birthDate) is an OPINIONATED,
+ * practical minimum for extraction — not a mirror of FHIR cardinality. See
+ * fhir-support-plan.md §5.
+ */
+export interface Patient {
+  resourceType: "Patient";
+  identifier?: Identifier[];
+  active?: boolean;
+  name: HumanName[];
+  gender: "male" | "female" | "other" | "unknown";
+  birthDate: string; // YYYY-MM-DD — validated as string only, not date format
+  telecom?: ContactPoint[];
+  address?: Address[];
+}
+
+const PatientJsonSchema = {
+  type: "object",
+  required: ["resourceType", "name", "gender", "birthDate"],
+  properties: {
+    resourceType: { type: "string", enum: ["Patient"] },
+    identifier: { type: "array", items: identifierSchema },
+    active: { type: "boolean" },
+    name: { type: "array", items: humanNameSchema },
+    gender: { type: "string", enum: ["male", "female", "other", "unknown"] },
+    birthDate: { type: "string" },
+    telecom: { type: "array", items: contactPointSchema },
+    address: { type: "array", items: addressSchema },
+  },
+};
+
+// Runtime value is a genuine { jsonSchema } object (so incremental streaming
+// validation and buildStructuredPrompt work); the annotation only narrows the
+// result type so generate() returns Patient instead of unknown.
+export const Patient: SchemaInput<Patient> = { jsonSchema: PatientJsonSchema };

--- a/src/fhir/types.ts
+++ b/src/fhir/types.ts
@@ -1,0 +1,150 @@
+/**
+ * Shared FHIR R4 primitive data types — TypeScript interfaces plus the
+ * reusable JSON Schema fragments the resource presets are built from.
+ *
+ * These model the COMMON subset of each primitive, not the full spec. See
+ * fhir-support-plan.md §6 for the honesty ledger on what is / isn't enforced.
+ */
+
+// ── TypeScript result interfaces ────────────────────────────────────────────
+
+export interface Coding {
+  system?: string;
+  code?: string;
+  display?: string;
+}
+
+export interface CodeableConcept {
+  coding?: Coding[];
+  text?: string;
+}
+
+export interface Reference {
+  reference?: string;
+  display?: string;
+}
+
+export interface HumanName {
+  use?: string;
+  text?: string;
+  family?: string;
+  given?: string[];
+  prefix?: string[];
+}
+
+export interface ContactPoint {
+  system?: string;
+  value?: string;
+  use?: string;
+}
+
+export interface Address {
+  use?: string;
+  line?: string[];
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string;
+}
+
+export interface Period {
+  start?: string;
+  end?: string;
+}
+
+export interface Quantity {
+  value?: number;
+  unit?: string;
+  system?: string;
+  code?: string;
+}
+
+export interface Identifier {
+  system?: string;
+  value?: string;
+}
+
+// ── JSON Schema fragments (embedded by the resource presets) ─────────────────
+
+export const codingSchema = {
+  type: "object",
+  properties: {
+    system: { type: "string" },
+    code: { type: "string" },
+    display: { type: "string" },
+  },
+};
+
+export const codeableConceptSchema = {
+  type: "object",
+  properties: {
+    coding: { type: "array", items: codingSchema },
+    text: { type: "string" },
+  },
+};
+
+export const referenceSchema = {
+  type: "object",
+  properties: {
+    reference: { type: "string" },
+    display: { type: "string" },
+  },
+};
+
+export const humanNameSchema = {
+  type: "object",
+  properties: {
+    use: { type: "string" },
+    text: { type: "string" },
+    family: { type: "string" },
+    given: { type: "array", items: { type: "string" } },
+    prefix: { type: "array", items: { type: "string" } },
+  },
+};
+
+export const contactPointSchema = {
+  type: "object",
+  properties: {
+    system: { type: "string" },
+    value: { type: "string" },
+    use: { type: "string" },
+  },
+};
+
+export const addressSchema = {
+  type: "object",
+  properties: {
+    use: { type: "string" },
+    line: { type: "array", items: { type: "string" } },
+    city: { type: "string" },
+    state: { type: "string" },
+    postalCode: { type: "string" },
+    country: { type: "string" },
+  },
+};
+
+export const periodSchema = {
+  type: "object",
+  properties: {
+    start: { type: "string" },
+    end: { type: "string" },
+  },
+};
+
+export const quantitySchema = {
+  type: "object",
+  properties: {
+    value: { type: "number" },
+    unit: { type: "string" },
+    system: { type: "string" },
+    code: { type: "string" },
+  },
+};
+
+export const identifierSchema = {
+  type: "object",
+  properties: {
+    system: { type: "string" },
+    value: { type: "string" },
+  },
+};

--- a/tests/fhir.test.ts
+++ b/tests/fhir.test.ts
@@ -1,0 +1,126 @@
+import { describe, it, expect } from "vitest";
+import type { ShapecraftModel } from "../src/types.js";
+import { SchemaViolationError } from "../src/types.js";
+import { generate } from "../src/core/generate.js";
+import { generateStream } from "../src/core/stream.js";
+import { fhir } from "../src/fhir/index.js";
+
+// Mock model that returns a fixed object (bypasses any real backend).
+function fixedModel(value: unknown): ShapecraftModel {
+  return {
+    id: "mock:fhir",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      return value as T;
+    },
+  };
+}
+
+// Mock streaming model that yields a JSON string as character-chunk deltas.
+function streamingModel(json: string): ShapecraftModel {
+  return {
+    id: "mock:fhir-stream",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      return JSON.parse(json) as T;
+    },
+    async *generateStream(): AsyncIterable<string> {
+      for (const ch of json) yield ch;
+    },
+  };
+}
+
+const validPatient = {
+  resourceType: "Patient",
+  name: [{ family: "Doe", given: ["John"] }],
+  gender: "male",
+  birthDate: "1990-02-11",
+};
+
+describe("fhir presets", () => {
+  it("exposes the five R4 resources", () => {
+    expect(Object.keys(fhir)).toEqual([
+      "Patient",
+      "Observation",
+      "Condition",
+      "MedicationRequest",
+      "Encounter",
+    ]);
+  });
+
+  it("each preset is a genuine { jsonSchema } SchemaInput at runtime", () => {
+    // The branded type must not hide the real runtime shape (streaming /
+    // incremental validation read schema.jsonSchema.properties).
+    for (const preset of Object.values(fhir)) {
+      expect(preset).toHaveProperty("jsonSchema");
+      expect((preset as { jsonSchema: { properties: unknown } }).jsonSchema.properties).toBeDefined();
+    }
+  });
+
+  it("validates a well-formed Patient", async () => {
+    const model = fixedModel(validPatient);
+    const { data } = await generate(model, fhir.Patient, "extract patient");
+    expect(data).toEqual(validPatient);
+  });
+
+  it("rejects a Patient missing a required field (birthDate)", async () => {
+    const model = fixedModel({ resourceType: "Patient", name: [{ family: "Doe" }], gender: "male" });
+    await expect(
+      generate(model, fhir.Patient, "extract patient", { maxRetries: 1 })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("enforces the gender value-set enum", async () => {
+    const model = fixedModel({ ...validPatient, gender: "M" });
+    await expect(
+      generate(model, fhir.Patient, "extract patient", { maxRetries: 1 })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("enforces Observation.status enum and requires code", async () => {
+    const badStatus = fixedModel({
+      resourceType: "Observation",
+      status: "done", // not in enum
+      code: { text: "BP" },
+    });
+    await expect(
+      generate(badStatus, fhir.Observation, "extract obs", { maxRetries: 1 })
+    ).rejects.toBeInstanceOf(Error);
+
+    const validObs = {
+      resourceType: "Observation",
+      status: "final",
+      code: { coding: [{ system: "http://loinc.org", code: "85354-9" }], text: "Blood pressure" },
+      valueQuantity: { value: 120, unit: "mmHg" },
+    };
+    const { data } = await generate(fixedModel(validObs), fhir.Observation, "extract obs");
+    expect(data).toEqual(validObs);
+  });
+
+  it("validates MedicationRequest with committed medicationCodeableConcept", async () => {
+    const rx = {
+      resourceType: "MedicationRequest",
+      status: "active",
+      intent: "order",
+      medicationCodeableConcept: { text: "Metformin 500mg" },
+      subject: { reference: "Patient/123" },
+    };
+    const { data } = await generate(fixedModel(rx), fhir.MedicationRequest, "extract rx");
+    expect(data).toEqual(rx);
+  });
+
+  it("emits per-field partial events streaming a Patient", async () => {
+    const model = streamingModel(JSON.stringify(validPatient));
+    const stream = generateStream(model, fhir.Patient, "extract patient");
+
+    const partialKeys: string[][] = [];
+    for await (const event of stream.events) {
+      if (event.type === "partial") partialKeys.push(Object.keys(event.value));
+    }
+    const { data } = await stream.result;
+
+    expect(data).toEqual(validPatient);
+    // top-level fields validated incrementally, in order, as each closes
+    expect(partialKeys.at(-1)).toEqual(["resourceType", "name", "gender", "birthDate"]);
+  });
+});

--- a/tests/fhir.test.ts
+++ b/tests/fhir.test.ts
@@ -109,6 +109,45 @@ describe("fhir presets", () => {
     expect(data).toEqual(rx);
   });
 
+  it("rejects a required field that is present but empty (constrained-grammar gap)", async () => {
+    // Repro: a constrained grammar forces birthDate to appear; the model has no
+    // value for it and emits "". `required` must treat that as missing, not pass.
+    const model = fixedModel({
+      resourceType: "Patient",
+      name: [{ text: "J.S." }],
+      gender: "unknown",
+      birthDate: "",
+    });
+    await expect(
+      generate(model, fhir.Patient, "extract patient", { maxRetries: 1 })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("rejects an empty array for a required field", async () => {
+    const model = fixedModel({
+      resourceType: "Patient",
+      name: [],
+      gender: "male",
+      birthDate: "1990-01-01",
+    });
+    await expect(
+      generate(model, fhir.Patient, "extract patient", { maxRetries: 1 })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
+  it("keeps 0 and false as valid required values", async () => {
+    // isNonEmpty must not reject falsy-but-real values.
+    const schema = {
+      jsonSchema: {
+        type: "object",
+        required: ["count", "active"],
+        properties: { count: { type: "number" }, active: { type: "boolean" } },
+      },
+    };
+    const { data } = await generate(fixedModel({ count: 0, active: false }), schema, "x");
+    expect(data).toEqual({ count: 0, active: false });
+  });
+
   it("emits per-field partial events streaming a Patient", async () => {
     const model = streamingModel(JSON.stringify(validPatient));
     const stream = generateStream(model, fhir.Patient, "extract patient");

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from "tsup";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
+  entry: ["src/index.ts", "src/fhir/index.ts"],
   format: ["esm", "cjs"],
   dts: false,
   sourcemap: true,


### PR DESCRIPTION
## Summary
- Adds Patient, Observation, Condition, MedicationRequest, and Encounter as ready-to-use
  FHIR R4 SchemaInputs via a separate `@aviasole/shapecraft/fhir` entrypoint - each is a
  typed result interface that works with `generate()`/`generateStream()` unchanged, no
  API changes to core.
- Fixes a real gap found while testing FHIR's required-field validation: `jsonSchema`'s
  `required` check only verified a field was present, not non-empty, so a constrained
  backend could satisfy a required field with `""`/`[]`/`{}`. Now matches the XML
  validation path (present AND non-empty).
- Version bump 2.0.4 -> 2.1.0 (minor, not patch - this is a real new feature).