### PR TITLE
feat: add raw GBNF grammar input + llamaCpp backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,50 @@
 # Changelog
 
+## [2.1.0] - 2026-07-06
+
+### Added
+- FHIR R4 preset schemas via `@aviasole/shapecraft/fhir` entrypoint - Patient, Observation,
+  Condition, MedicationRequest, Encounter. Each is a ready-to-use `SchemaInput` with a typed
+  result interface, so it works with `generate()`/`generateStream()` unchanged.
+- Raw GBNF grammar input - `generate(model, { gbnf: grammarString }, prompt)`. Output is the
+  raw string that conforms to the grammar.
+- `llamaCpp()` backend (node-llama-cpp) - applies a GBNF grammar at the token level, so
+  output is valid by construction (`constrained`).
+- Bundled pragmatic GBNF interpreter (`matchesGbnf`, `parseGbnf`, `buildGbnfSystemPrompt`
+  exported) - validates grammar output on backends without a native grammar parameter, and
+  fails fast on a malformed grammar before any model call.
+- Streaming for `{ gbnf }` emits `delta`/`done` only (no per-field `partial`), consistent
+  with other string-language inputs.
+
+### Fixed
+- `checkJsonSchema` enforces `required` fields as present AND non-empty, matching the XML
+  validation path - stops a constrained grammar from satisfying a required field with an
+  empty `""`/`[]`/`{}`.
+- `groq()` no longer forces `response_format: json_object` for `{ gbnf }` inputs (it already
+  skipped this for `{ xml }`, but not `gbnf`) - Groq's API rejects json_object mode outright
+  when the prompt doesn't contain the word "json", which broke every gbnf call on this
+  backend. Fixed in both `generate()` and `generateStream()`.
+- `matchesGbnf` now throws a clear, actionable error ("recursion is too deep... prefer
+  `*`/`+`") when a deeply right-recursive rule reference exceeds the JS call stack
+  (empirically ~900-1000 repetitions), instead of letting a raw native stack-overflow
+  `RangeError` propagate.
+
+## [2.0.1] - 2026-07-04
+
+### Added
+- `generateStream()` - streams tokens live for UX while validating the assembled response
+  exactly once, through the same pipeline as `generate()`.
+- `StreamHandle` with two independent views: `textStream` (raw text deltas) and `events`
+  (full lifecycle: `attempt-start`, `delta`, `partial`, `attempt-failed`, `done`).
+- Incremental per-field validation (`partial` events) - for JSON/Zod object schemas, each
+  top-level field is validated the instant its own value closes in the stream, before the
+  whole object finishes.
+- Visible retries - a streaming attempt that fails validation emits `attempt-failed` and
+  starts a fresh `attempt-start`, since already-streamed tokens can't be un-sent.
+- `generateStream()` added to all four backends (openai, groq, anthropic, ollama), falling
+  back to one-shot `generate()` for a model without native streaming support.
+- `checkJsonSchema` exported from `core/validate.ts` for reuse by the incremental validator.
+
 ## [0.1.0] - 2026-06-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -224,21 +224,108 @@ console.log(result.data); // { name: "John Doe", age: 35 }
 > XML is prompt-driven on all backends (no token-level constraint), so a capable
 > model gives the most reliable output on deeply nested templates.
 
+### GBNF grammar
+
+Pass a raw [GBNF](https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md)
+(GGML BNF) grammar string. `result.data` is the **raw string** that conforms to the
+grammar — GBNF describes a string language, not a JSON shape, so it's never parsed.
+
+```typescript
+const result = await generate(model, {
+  gbnf: `
+    root  ::= year "-" month "-" day
+    year  ::= [0-9]{4}
+    month ::= [0-9]{2}
+    day   ::= [0-9]{2}
+  `,
+}, "When did WWII end in Europe?");
+
+console.log(result.data); // "1945-05-08"
+```
+
+**The guarantee is backend-dependent — this is the one input where that's true.** On
+`llamaCpp()` the grammar is enforced at the **token level**: the model literally cannot
+emit a token that breaks the grammar, so the output is valid *by construction*
+(`constrained`). On every other backend (`openai`, `groq`, `anthropic`, `ollama`) there
+is no grammar parameter, so the grammar is injected into the prompt (best-effort) and the
+returned string is validated against the grammar by a **bundled GBNF interpreter**, then
+retried on a mismatch.
+
+```typescript
+import { llamaCpp } from "@aviasole/shapecraft";
+
+const local = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" }); // npm install node-llama-cpp
+const { data } = await generate(local, {
+  gbnf: `root ::= "positive" | "negative" | "neutral"`,
+}, "Sentiment of: 'I love this!'");
+// data: "positive" — constrained, cannot be anything else
+```
+
+#### What the interpreter enforces (and what it doesn't)
+
+The bundled interpreter is a deliberate **subset**, in the same spirit as `checkJsonSchema`
+(a useful subset of JSON Schema, not the whole spec). A malformed grammar, or one using an
+unsupported construct, throws **before the model is ever called** — a grammar bug, not
+something to retry.
+
+| GBNF construct | Supported |
+|---|---|
+| String literals, rule references, sequences | ✅ |
+| Alternation `\|`, grouping `( )` | ✅ |
+| Repetition `*` `+` `?` `{m}` `{m,}` `{m,n}` | ✅ |
+| Character classes `[a-z]` `[^0-9]`, ranges, escapes (`\n \t \" \xNN \uNNNN`) | ✅ |
+| `#` line comments | ✅ |
+| **Left-recursive rules** | ⚠️ not fully supported — validation may reject; never hangs |
+| **Deeply right-recursive rule *references*** (`list ::= item "," list \| item`) | ⚠️ has a real depth limit (see below) |
+| Nested/imported grammars, llama.cpp extensions | ❌ throws at parse time |
+
+The subset applies on **all** backends, including `llamaCpp()` (the JS validation still runs
+for pipeline uniformity). As always, the grammar constrains **shape, not truth** — a
+conforming string can still be a wrong answer (see
+[guarantees](#what-shapecraft-guarantees--and-what-it-doesnt)).
+
+**Stress-tested failure modes (what actually breaks, found by deliberately trying to break it):**
+
+- **Catastrophic/exponential backtracking — not reproducible.** The classic patterns that
+  blow up naive backtracking regex engines (e.g. `("a" "a"?)* "b"` against a long run of `a`
+  with no trailing `b`) resolve in milliseconds here, because the matcher dedupes by
+  *position reached*, not by path taken — it's closer to a bounded reachability search than
+  a naive backtracker.
+- **A genuinely adversarial grammar can still exceed the step budget** — a ~26-way
+  variable-length ambiguous alternation over a 300k-character input with an unmatchable
+  terminator trips it in well under a second, throwing a clear "step budget" error rather
+  than hanging. This is a real, if hard-to-reach, backstop — not just an untested code path.
+- **Deep right-recursion via a rule *reference* has a hard limit — this is a real gap, not
+  just theoretical.** `*` and `+` are matched iteratively (no recursion, no limit tested up to
+  50k+ repetitions). But a rule written as `list ::= item "," list | item` recurses through
+  the JS call stack once per repetition, and breaks — empirically, somewhere in the
+  900–1000 repetition range on a typical build. Past that point `matchesGbnf` throws a clear,
+  actionable error (*"GBNF grammar recursion is too deep... prefer `*`/`+`"*) instead of a raw
+  native stack-overflow trace. **If your grammar needs a long repeated sequence, write it
+  with `*`/`+`, not recursive rule references** — this is the one place "conventionally
+  right-recursive GBNF" needs a caveat.
+
 ## Backends & Guarantee Levels
 
 | Backend | Guarantee | Mechanism |
 |---|---|---|
 | `openai()` | `native` | Server-side strict JSON schema |
 | `groq()` | `native` | JSON mode |
-| `ollama()` | `constrained` | Token-level GBNF grammar |
+| `ollama()` | `constrained` | Token-level JSON-schema constraint |
+| `llamaCpp()` | `constrained` | Token-level GBNF grammar (local `.gguf` via node-llama-cpp) |
 | `anthropic()` | `best-effort` | Prompt + parse + retry |
 
+> `llamaCpp()` is `constrained` for a `{ gbnf }` input (token-level). For other schema
+> types (Zod / jsonSchema / …) it currently runs a best-effort prompt path until the
+> JSON-Schema→GBNF converter lands — treat those as best-effort despite the nominal level.
+
 ```typescript
-import { openai, groq, ollama, anthropic } from "@aviasole/shapecraft";
+import { openai, groq, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
 
 const gpt    = openai({ model: "gpt-4o-mini" });
 const fast   = groq({ model: "llama-3.3-70b-versatile" });
 const local  = ollama({ model: "llama3.2" });
+const native = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });
 const claude = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
 ```
 

--- a/examples/gbnf.ts
+++ b/examples/gbnf.ts
@@ -1,0 +1,40 @@
+/**
+ * Example: Raw GBNF grammar input.
+ *
+ * On a llama.cpp-family backend (`llamaCpp()`) the grammar is applied at the
+ * token level — the output is valid by construction (`constrained`). On any
+ * other backend the grammar is injected into the prompt (best-effort) and the
+ * returned string is validated against the grammar by shapecraft's bundled
+ * GBNF interpreter. Output is always the raw matched string.
+ */
+import { generate, openai, llamaCpp } from "@aviasole/shapecraft";
+
+// A grammar for an ISO date.
+const dateGrammar = `
+root  ::= year "-" month "-" day
+year  ::= [0-9]{4}
+month ::= [0-9]{2}
+day   ::= [0-9]{2}
+`;
+
+// A grammar for a fixed enum (classification).
+const sentimentGrammar = `root ::= "positive" | "negative" | "neutral"`;
+
+// ── Best-effort on a cloud backend (prompt + validate) ────────────────────────
+const gpt = openai({ model: "gpt-4o-mini" });
+
+const date = await generate(gpt, { gbnf: dateGrammar }, "When did WWII end in Europe?");
+console.log(date.data); // "1945-05-08"
+console.log(date.guaranteeLevel); // "best-effort" is the *effective* guarantee here
+
+// ── Token-level constraint on a local model (valid by construction) ───────────
+// Requires: npm install node-llama-cpp, and a local .gguf model file.
+const local = llamaCpp({ modelPath: "./models/llama-3.2-3b-instruct.gguf" });
+
+const sentiment = await generate(
+  local,
+  { gbnf: sentimentGrammar },
+  "Classify the sentiment: 'I absolutely love this product!'"
+);
+console.log(sentiment.data); // "positive" — the model literally cannot emit anything else
+console.log(sentiment.guaranteeLevel); // "constrained"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -1,7 +1,13 @@
 import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
-import { isXmlInput } from "../core/validate.js";
+import { isXmlInput, isGbnfInput } from "../core/validate.js";
+
+function wantsJsonMode(schema: SchemaInput): boolean {
+  // XML and GBNF output free-form strings, not JSON — Groq rejects json_object
+  // mode when the prompt doesn't literally contain the word "json".
+  return !isXmlInput(schema) && !isGbnfInput(schema);
+}
 
 export interface GroqBackendOptions {
   model?: string;
@@ -35,8 +41,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
           { role: "system", content: system },
           { role: "user", content: user },
         ],
-        // XML schemas must not use json_object mode — Groq rejects it when prompt lacks "json"
-        ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
+        ...(wantsJsonMode(schema) ? { response_format: { type: "json_object" } } : {}),
       });
 
       const raw: string = response.choices[0]?.message?.content ?? "";
@@ -68,7 +73,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
           { role: "system", content: system },
           { role: "user", content: user },
         ],
-        ...(!isXmlInput(schema) ? { response_format: { type: "json_object" } } : {}),
+        ...(wantsJsonMode(schema) ? { response_format: { type: "json_object" } } : {}),
         stream: true,
       });
 

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -2,3 +2,4 @@ export { openai } from "./openai.js";
 export { ollama } from "./ollama.js";
 export { anthropic } from "./anthropic.js";
 export { groq } from "./groq.js";
+export { llamaCpp } from "./llamaCpp.js";

--- a/src/backends/llamaCpp.ts
+++ b/src/backends/llamaCpp.ts
@@ -1,0 +1,107 @@
+import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
+import { buildStructuredPrompt } from "../core/schema.js";
+import { parseAndValidate } from "../core/parse.js";
+import { isGbnfInput } from "../core/validate.js";
+import { parseGbnf } from "../core/gbnf.js";
+
+export interface LlamaCppBackendOptions {
+  /** Path to a local .gguf model file. */
+  modelPath: string;
+  /** Layers to offload to the GPU (node-llama-cpp default if omitted). */
+  gpuLayers?: number;
+  /** Context window size. */
+  contextSize?: number;
+}
+
+/**
+ * node-llama-cpp backend — the first-class GBNF target. For a `{ gbnf }` input
+ * the grammar is applied at the **token level**, so the output cannot violate it
+ * (`guaranteeLevel: "constrained"`, valid by construction).
+ *
+ * For other schema types (Zod / jsonSchema / pattern / xml / validator) this
+ * backend currently runs a prompt-only, best-effort path — it does not yet
+ * convert those to a grammar (that's the deferred JSON-Schema→GBNF converter).
+ * Until then, treat non-`gbnf` inputs on `llamaCpp()` as best-effort despite the
+ * nominal `constrained` level.
+ */
+export function llamaCpp(options: LlamaCppBackendOptions): ShapecraftModel {
+  // The model load is the expensive step — do it once, lazily, and reuse it
+  // across calls. A fresh context/session is created per generate() call.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let loaded: Promise<{ llama: any; model: any; mod: any }> | null = null;
+
+  function load() {
+    if (!loaded) {
+      loaded = (async () => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const mod: any = await import("node-llama-cpp").catch(() => {
+          throw new Error("Install node-llama-cpp: npm install node-llama-cpp");
+        });
+        const llama = await mod.getLlama();
+        const model = await llama.loadModel({ modelPath: options.modelPath, gpuLayers: options.gpuLayers });
+        return { llama, model, mod };
+      })();
+    }
+    return loaded;
+  }
+
+  return {
+    id: `llamacpp:${options.modelPath}`,
+    guaranteeLevel: "constrained",
+
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
+      // Fail fast on a malformed grammar before loading a multi-GB model.
+      if (isGbnfInput(schema)) parseGbnf(schema.gbnf);
+
+      const { llama, model, mod } = await load();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      let grammar: any;
+      if (isGbnfInput(schema)) {
+        grammar = await llama.createGrammar({ grammar: schema.gbnf });
+      }
+
+      const context = await model.createContext(
+        options.contextSize ? { contextSize: options.contextSize } : {}
+      );
+      try {
+        const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+        const session = new mod.LlamaChatSession({
+          contextSequence: context.getSequence(),
+          systemPrompt: system,
+        });
+        const answer: string = await session.prompt(user, grammar ? { grammar } : {});
+        return parseAndValidate<T>(answer, schema);
+      } finally {
+        await context.dispose?.();
+      }
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const { model, mod } = await load();
+      const context = await model.createContext(
+        options.contextSize ? { contextSize: options.contextSize } : {}
+      );
+      try {
+        const session = new mod.LlamaChatSession({
+          contextSequence: context.getSequence(),
+          systemPrompt,
+        });
+        // Replay all but the last turn as history, prompt with the last.
+        const history = messages.slice(0, -1);
+        const last = messages[messages.length - 1];
+        if (history.length > 0 && typeof session.setChatHistory === "function") {
+          session.setChatHistory(
+            history.map((m) => ({
+              type: m.role === "user" ? "user" : "model",
+              text: m.content,
+            }))
+          );
+        }
+        return await session.prompt(last?.content ?? "");
+      } finally {
+        await context.dispose?.();
+      }
+    },
+  };
+}

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
 import type { ChatMessage, SchemaInput, ShapecraftModel } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
-import { isZodSchema } from "../core/validate.js";
+import { isZodSchema, isGbnfInput } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
 
 export interface OpenAIBackendOptions {
@@ -12,6 +12,9 @@ export interface OpenAIBackendOptions {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function responseFormatFor(schema: SchemaInput): any {
+  // GBNF output is a free-form string, not JSON — do NOT force json_object,
+  // it would corrupt the grammar-constrained output. Prompt-only (best-effort).
+  if (isGbnfInput(schema)) return undefined;
   // Strict json_schema mode for Zod, non-strict for raw jsonSchema, json_object otherwise
   return isZodSchema(schema)
     ? {

--- a/src/core/gbnf.ts
+++ b/src/core/gbnf.ts
@@ -1,0 +1,421 @@
+import type { GbnfInput } from "../types.js";
+
+/**
+ * A pragmatic GBNF (GGML BNF) grammar interpreter — the same subset posture as
+ * `checkJsonSchema` (a useful subset of JSON Schema, not the whole spec). It
+ * parses a grammar once, then checks whether a candidate string is in the
+ * grammar's language. Used to validate output on backends that cannot apply the
+ * grammar at the token level (everything except `llamaCpp()`).
+ *
+ * Supported: string literals, rule references, sequences, alternation `|`,
+ * grouping `( )`, repetition `* + ? {m} {m,} {m,n}`, character classes
+ * `[a-z] [^0-9]` with ranges and escapes (`\n \t \" \\ \xNN \uNNNN \UNNNNNNNN`),
+ * and `#` line comments. Not supported (documented in the README ledger):
+ * left-recursive rules (matched as nothing, never hangs), nested/imported
+ * grammars, and llama.cpp-specific extensions — an unsupported construct throws
+ * at parse time, before the model is ever called.
+ */
+
+type GNode =
+  | { type: "lit"; value: string }
+  | { type: "class"; negated: boolean; ranges: Array<[number, number]> }
+  | { type: "ref"; name: string }
+  | { type: "seq"; items: GNode[] }
+  | { type: "alt"; options: GNode[] }
+  | { type: "rep"; node: GNode; min: number; max: number };
+
+export type GbnfGrammar = Map<string, GNode>;
+
+function fail(msg: string): never {
+  throw new Error(`Invalid GBNF grammar: ${msg}`);
+}
+
+class GbnfParser {
+  private pos = 0;
+  constructor(private readonly src: string) {}
+
+  parse(): GbnfGrammar {
+    const rules: GbnfGrammar = new Map();
+    this.skipWs();
+    while (this.pos < this.src.length) {
+      const name = this.parseName();
+      this.skipWs();
+      this.expect("::=");
+      rules.set(name, this.parseAlternation());
+      this.skipWs();
+    }
+    if (rules.size === 0) fail("grammar is empty");
+    if (!rules.has("root")) fail("grammar has no `root` rule (the entry point)");
+    return rules;
+  }
+
+  private skipWs(): void {
+    while (this.pos < this.src.length) {
+      const c = this.src[this.pos]!;
+      if (c === " " || c === "\t" || c === "\r" || c === "\n") {
+        this.pos++;
+        continue;
+      }
+      if (c === "#") {
+        // line comment — skip to end of line (never inside a string/class, since
+        // those are consumed whole by their own parsers)
+        while (this.pos < this.src.length && this.src[this.pos] !== "\n") this.pos++;
+        continue;
+      }
+      break;
+    }
+  }
+
+  private expect(s: string): void {
+    if (this.src.startsWith(s, this.pos)) {
+      this.pos += s.length;
+      return;
+    }
+    fail(`expected "${s}" at position ${this.pos}`);
+  }
+
+  private isNameStart(c: string | undefined): boolean {
+    return !!c && ((c >= "a" && c <= "z") || (c >= "A" && c <= "Z"));
+  }
+
+  private isNameChar(c: string | undefined): boolean {
+    return !!c && (this.isNameStart(c) || (c >= "0" && c <= "9") || c === "-");
+  }
+
+  private parseName(): string {
+    this.skipWs();
+    if (!this.isNameStart(this.src[this.pos])) fail(`expected a rule name at position ${this.pos}`);
+    const start = this.pos;
+    this.pos++;
+    while (this.isNameChar(this.src[this.pos])) this.pos++;
+    return this.src.slice(start, this.pos);
+  }
+
+  private parseAlternation(): GNode {
+    const options: GNode[] = [this.parseSequence()];
+    this.skipWs();
+    while (this.src[this.pos] === "|") {
+      this.pos++;
+      options.push(this.parseSequence());
+      this.skipWs();
+    }
+    return options.length === 1 ? options[0]! : { type: "alt", options };
+  }
+
+  private parseSequence(): GNode {
+    const items: GNode[] = [];
+    while (true) {
+      this.skipWs();
+      const c = this.src[this.pos];
+      if (this.pos >= this.src.length || c === "|" || c === ")") break;
+      if (this.atRuleStart()) break; // start of the next `name ::=` rule
+      items.push(this.parseElement());
+    }
+    // An empty sequence (e.g. `( )` or `"a" | `) is the empty match.
+    if (items.length === 0) return { type: "lit", value: "" };
+    return items.length === 1 ? items[0]! : { type: "seq", items };
+  }
+
+  /** Lookahead: are we at the start of a new `name ::=` rule (vs. a reference)? */
+  private atRuleStart(): boolean {
+    const save = this.pos;
+    try {
+      if (!this.isNameStart(this.src[this.pos])) return false;
+      this.pos++;
+      while (this.isNameChar(this.src[this.pos])) this.pos++;
+      this.skipWs();
+      return this.src.startsWith("::=", this.pos);
+    } finally {
+      this.pos = save;
+    }
+  }
+
+  private parseElement(): GNode {
+    this.skipWs();
+    const c = this.src[this.pos];
+    let node: GNode;
+    if (c === '"') node = this.parseString();
+    else if (c === "[") node = this.parseClass();
+    else if (c === "(") {
+      this.pos++;
+      node = this.parseAlternation();
+      this.skipWs();
+      this.expect(")");
+    } else if (this.isNameStart(c)) {
+      node = { type: "ref", name: this.parseName() };
+    } else {
+      fail(`unexpected character ${JSON.stringify(c ?? "<eof>")} at position ${this.pos}`);
+    }
+    return this.parsePostfix(node);
+  }
+
+  private parsePostfix(node: GNode): GNode {
+    const c = this.src[this.pos];
+    if (c === "*") {
+      this.pos++;
+      return { type: "rep", node, min: 0, max: Infinity };
+    }
+    if (c === "+") {
+      this.pos++;
+      return { type: "rep", node, min: 1, max: Infinity };
+    }
+    if (c === "?") {
+      this.pos++;
+      return { type: "rep", node, min: 0, max: 1 };
+    }
+    if (c === "{") return this.parseBraceRep(node);
+    return node;
+  }
+
+  private parseBraceRep(node: GNode): GNode {
+    this.pos++; // consume "{"
+    const readInt = (): number => {
+      const start = this.pos;
+      while (this.src[this.pos]! >= "0" && this.src[this.pos]! <= "9") this.pos++;
+      if (this.pos === start) fail(`expected a number in {m,n} at position ${this.pos}`);
+      return parseInt(this.src.slice(start, this.pos), 10);
+    };
+    const min = readInt();
+    let max = min;
+    if (this.src[this.pos] === ",") {
+      this.pos++;
+      max = this.src[this.pos] === "}" ? Infinity : readInt();
+    }
+    this.expect("}");
+    if (max < min) fail(`repetition {${min},${max}} has max < min`);
+    return { type: "rep", node, min, max };
+  }
+
+  private parseString(): GNode {
+    this.pos++; // opening quote
+    let value = "";
+    while (this.pos < this.src.length) {
+      const c = this.src[this.pos]!;
+      if (c === '"') {
+        this.pos++;
+        return { type: "lit", value };
+      }
+      if (c === "\\") {
+        this.pos++;
+        value += String.fromCodePoint(this.readEscape());
+        continue;
+      }
+      value += c;
+      this.pos++;
+    }
+    return fail("unterminated string literal");
+  }
+
+  private parseClass(): GNode {
+    this.pos++; // "["
+    let negated = false;
+    if (this.src[this.pos] === "^") {
+      negated = true;
+      this.pos++;
+    }
+    const ranges: Array<[number, number]> = [];
+    while (this.pos < this.src.length) {
+      if (this.src[this.pos] === "]") {
+        this.pos++;
+        return { type: "class", negated, ranges };
+      }
+      const lo = this.readClassChar();
+      // "a-z" range, but a trailing "-" (before "]") is a literal dash
+      if (this.src[this.pos] === "-" && this.src[this.pos + 1] !== "]") {
+        this.pos++; // "-"
+        const hi = this.readClassChar();
+        ranges.push([lo, hi]);
+      } else {
+        ranges.push([lo, lo]);
+      }
+    }
+    return fail("unterminated character class");
+  }
+
+  private readClassChar(): number {
+    if (this.src[this.pos] === "\\") {
+      this.pos++;
+      return this.readEscape();
+    }
+    const cp = this.src.codePointAt(this.pos)!;
+    this.pos += cp > 0xffff ? 2 : 1;
+    return cp;
+  }
+
+  private readEscape(): number {
+    const c = this.src[this.pos];
+    this.pos++;
+    switch (c) {
+      case "n": return 0x0a;
+      case "r": return 0x0d;
+      case "t": return 0x09;
+      case "\\": return 0x5c;
+      case '"': return 0x22;
+      case "'": return 0x27;
+      case "[": return 0x5b;
+      case "]": return 0x5d;
+      case "-": return 0x2d;
+      case "/": return 0x2f;
+      case "x": return this.readHex(2);
+      case "u": return this.readHex(4);
+      case "U": return this.readHex(8);
+      default:
+        if (c === undefined) return fail("dangling escape at end of grammar");
+        return c.codePointAt(0)!; // any other escaped char is that literal char
+    }
+  }
+
+  private readHex(n: number): number {
+    const start = this.pos;
+    for (let i = 0; i < n; i++) {
+      const c = this.src[this.pos];
+      const isHex = !!c && ((c >= "0" && c <= "9") || (c >= "a" && c <= "f") || (c >= "A" && c <= "F"));
+      if (!isHex) fail(`expected ${n}-digit hex escape at position ${start}`);
+      this.pos++;
+    }
+    return parseInt(this.src.slice(start, this.pos), 16);
+  }
+}
+
+// Grammars are small and re-validated across retries — cache the parse.
+const parseCache = new Map<string, GbnfGrammar>();
+
+export function parseGbnf(source: string): GbnfGrammar {
+  const cached = parseCache.get(source);
+  if (cached) return cached;
+  const grammar = new GbnfParser(source).parse();
+  parseCache.set(source, grammar);
+  return grammar;
+}
+
+const STEP_BUDGET = 2_000_000;
+
+/**
+ * Returns true iff `input` is fully in the language of the grammar's `root`
+ * rule. A set-returning matcher (each node yields the set of positions it can
+ * end at) — this handles alternation, greedy/backtracking repetition, and
+ * optional/right-recursive rules without the entanglement a continuation-passing
+ * matcher has, and it detects left recursion cleanly (a left-recursive rule
+ * contributes no positions, so it never hangs).
+ */
+export function matchesGbnf(source: string, input: string): boolean {
+  const rules = parseGbnf(source);
+  const inProgress = new Set<string>();
+  let steps = 0;
+
+  function matchSet(node: GNode, pos: number): Set<number> {
+    if (++steps > STEP_BUDGET) {
+      throw new Error("GBNF match exceeded step budget — grammar is too ambiguous for this input");
+    }
+
+    switch (node.type) {
+      case "lit":
+        return input.startsWith(node.value, pos) ? new Set([pos + node.value.length]) : new Set();
+
+      case "class": {
+        if (pos >= input.length) return new Set();
+        const cp = input.codePointAt(pos)!;
+        const width = cp > 0xffff ? 2 : 1;
+        let inRange = false;
+        for (const [lo, hi] of node.ranges) {
+          if (cp >= lo && cp <= hi) {
+            inRange = true;
+            break;
+          }
+        }
+        return inRange !== node.negated ? new Set([pos + width]) : new Set();
+      }
+
+      case "ref": {
+        const target = rules.get(node.name);
+        if (!target) throw new Error(`Invalid GBNF grammar: references undefined rule "${node.name}"`);
+        const key = `${node.name}@${pos}`;
+        if (inProgress.has(key)) return new Set(); // left recursion at this position — dead end
+        inProgress.add(key);
+        const out = matchSet(target, pos);
+        inProgress.delete(key);
+        return out;
+      }
+
+      case "seq": {
+        let frontier = new Set<number>([pos]);
+        for (const item of node.items) {
+          const next = new Set<number>();
+          for (const p of frontier) for (const np of matchSet(item, p)) next.add(np);
+          if (next.size === 0) return next;
+          frontier = next;
+        }
+        return frontier;
+      }
+
+      case "alt": {
+        const out = new Set<number>();
+        for (const opt of node.options) for (const np of matchSet(opt, pos)) out.add(np);
+        return out;
+      }
+
+      case "rep": {
+        // BFS over repetition counts. Positions strictly advance each step (we
+        // skip zero-width matches), so this terminates even for unbounded `max`.
+        const out = new Set<number>();
+        if (node.min === 0) out.add(pos);
+        const seen = new Set<number>([pos]);
+        let frontier = new Set<number>([pos]);
+        let count = 0;
+        while (count < node.max && frontier.size > 0) {
+          const next = new Set<number>();
+          for (const p of frontier) {
+            for (const np of matchSet(node.node, p)) {
+              if (np === p) continue; // zero-width — cannot make progress
+              next.add(np);
+            }
+          }
+          count++;
+          if (count >= node.min) for (const np of next) out.add(np);
+          frontier = new Set<number>();
+          for (const np of next) {
+            if (!seen.has(np)) {
+              seen.add(np);
+              frontier.add(np);
+            }
+          }
+        }
+        return out;
+      }
+    }
+  }
+
+  try {
+    return matchSet(rules.get("root")!, 0).has(input.length);
+  } catch (err) {
+    // matchSet recurses through the JS call stack for every rule *reference*
+    // (unlike `*`/`+`, which are iterative BFS and never recurse) — a
+    // deeply right-recursive rule (`list ::= item "," list | item`) against a
+    // long input can exhaust it. Surface a clear, documented failure instead
+    // of a raw native RangeError with an unrelated-looking stack trace.
+    if (err instanceof RangeError) {
+      throw new Error(
+        "GBNF grammar recursion is too deep for this input — a right-recursive rule " +
+          "(e.g. `list ::= item \",\" list | item`) needs one JS call per repetition. " +
+          "Prefer `*`/`+` over recursive rule references for long repeated sequences " +
+          "(they're matched iteratively and have no depth limit)."
+      );
+    }
+    throw err;
+  }
+}
+
+/**
+ * System-prompt instruction for backends that cannot apply the grammar at the
+ * token level. Embeds the grammar text and asks for a bare conforming string.
+ * Parses the grammar as a side effect so an invalid grammar throws here —
+ * before any model call — the same fail-fast contract the XML template has.
+ */
+export function buildGbnfSystemPrompt(schema: GbnfInput): string {
+  parseGbnf(schema.gbnf); // validate up front; throws on a malformed grammar
+  return (
+    `Respond with a single output string that conforms EXACTLY to the following ` +
+    `GBNF grammar. Output only that string — no markdown, no code fences, no ` +
+    `explanation, no surrounding quotes.\n\nGBNF grammar:\n${schema.gbnf}`
+  );
+}

--- a/src/core/incremental.ts
+++ b/src/core/incremental.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { SchemaInput } from "../types.js";
-import { checkJsonSchema, isXmlInput } from "./validate.js";
+import { checkJsonSchema, isXmlInput, isGbnfInput } from "./validate.js";
 
 /**
  * Scans a growing JSON buffer for top-level object fields whose value has
@@ -152,7 +152,7 @@ export function extractCompletedTopLevelFields(buffer: string): Record<string, s
  * XML, pattern, and custom-validator schemas never decompose).
  */
 export function validateFieldIfPossible<T>(schema: SchemaInput<T>, key: string, value: unknown): string | null {
-  if (isXmlInput(schema)) return null;
+  if (isXmlInput(schema) || isGbnfInput(schema)) return null;
 
   if (schema instanceof z.ZodType) {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/core/parse.ts
+++ b/src/core/parse.ts
@@ -1,7 +1,8 @@
 import type { SchemaInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
-import { isZodSchema, isXmlInput } from "./validate.js";
+import { isZodSchema, isXmlInput, isGbnfInput } from "./validate.js";
 import { finalizeXmlOutput } from "./xml.js";
+import { matchesGbnf } from "./gbnf.js";
 
 export function parseAndValidate<T>(
   raw: string,
@@ -10,6 +11,15 @@ export function parseAndValidate<T>(
 ): T {
   // Pattern schemas return the raw string directly — no JSON parsing
   if ("pattern" in (schema as object)) return raw as T;
+
+  // GBNF schemas — raw string, validated against the grammar (so streaming
+  // validates it too, not just the non-streaming validateOutput path)
+  if (isGbnfInput(schema)) {
+    if (!matchesGbnf(schema.gbnf, raw)) {
+      throw new SchemaViolationError(raw, "Output does not conform to the GBNF grammar");
+    }
+    return raw as T;
+  }
 
   // XML schemas — parse XML then validate structure
   if (isXmlInput(schema)) {

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -2,7 +2,8 @@ import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 import type { SchemaInput, ValidatorInput } from "../types.js";
 import { buildXmlSystemPrompt } from "./xml.js";
-import { isXmlInput } from "./validate.js";
+import { buildGbnfSystemPrompt } from "./gbnf.js";
+import { isXmlInput, isGbnfInput } from "./validate.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toJsonSchema(schema: z.ZodType<any>): Record<string, unknown> {
@@ -23,6 +24,8 @@ export function buildStructuredPrompt(
     schemaInfo = `Respond with valid JSON matching this schema exactly:\n\n${JSON.stringify(schema.jsonSchema, null, 2)}`;
   } else if ("pattern" in schema) {
     schemaInfo = `Respond with a plain string matching this pattern: ${schema.pattern}`;
+  } else if (isGbnfInput(schema)) {
+    schemaInfo = buildGbnfSystemPrompt(schema);
   } else if (isXmlInput(schema)) {
     schemaInfo = buildXmlSystemPrompt(schema);
   } else if ("validate" in schema && (schema as ValidatorInput).hint) {

--- a/src/core/stream.ts
+++ b/src/core/stream.ts
@@ -3,6 +3,7 @@ import { MaxRetriesExceededError, SchemaViolationError } from "../types.js";
 import { generate } from "./generate.js";
 import { parseAndValidate } from "./parse.js";
 import { extractCompletedTopLevelFields, validateFieldIfPossible } from "./incremental.js";
+import { isGbnfInput } from "./validate.js";
 
 /**
  * Single-consumer async channel. textStream and events are two independent
@@ -112,8 +113,10 @@ export function generateStream<T>(
           // JSON closes, check it against its own sub-schema immediately,
           // instead of waiting for the whole object. Only applies to schemas
           // that decompose into named fields (Zod object / jsonSchema with
-          // properties) — everything else is a no-op here.
-          const completedFields = extractCompletedTopLevelFields(buffer);
+          // properties) — everything else is a no-op here. GBNF is a string
+          // language: a JSON-shaped grammar could otherwise trip the field
+          // scanner into emitting misleading `partial` events, so skip it.
+          const completedFields = isGbnfInput(schema) ? {} : extractCompletedTopLevelFields(buffer);
           for (const [key, raw] of Object.entries(completedFields)) {
             if (validatedKeys.has(key)) continue;
             validatedKeys.add(key);

--- a/src/core/validate.ts
+++ b/src/core/validate.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
-import type { SchemaInput, XmlInput } from "../types.js";
+import type { GbnfInput, SchemaInput, XmlInput } from "../types.js";
 import { SchemaViolationError } from "../types.js";
 import { finalizeXmlOutput, isNonEmpty } from "./xml.js";
+import { matchesGbnf } from "./gbnf.js";
 
 export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
   return schema instanceof z.ZodType;
@@ -9,6 +10,10 @@ export function isZodSchema(schema: SchemaInput): schema is z.ZodType<any> {
 
 export function isXmlInput(schema: SchemaInput): schema is XmlInput {
   return typeof schema === "object" && schema !== null && "xml" in schema;
+}
+
+export function isGbnfInput(schema: SchemaInput): schema is GbnfInput {
+  return typeof schema === "object" && schema !== null && "gbnf" in schema;
 }
 
 function nullToUndefined(value: unknown): unknown {
@@ -85,6 +90,17 @@ export function validateOutput<T>(output: unknown, schema: SchemaInput<T>): T {
       throw new SchemaViolationError(str, `Output does not match pattern ${schema.pattern}`);
     }
     return output as T;
+  }
+
+  if (isGbnfInput(schema)) {
+    // GBNF output is always a raw string (like `pattern`). On llamaCpp() the
+    // grammar was applied at the token level so this is a guaranteed no-op; on
+    // any other backend it is the actual structural check.
+    const str = typeof output === "string" ? output : JSON.stringify(output);
+    if (!matchesGbnf(schema.gbnf, str)) {
+      throw new SchemaViolationError(str, "Output does not conform to the GBNF grammar");
+    }
+    return str as T;
   }
 
   if ("validate" in schema) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { generate } from "./core/generate.js";
 export { generateStream } from "./core/stream.js";
 export { toJsonSchema, buildStructuredPrompt } from "./core/schema.js";
 export { xmlType, validateXmlTemplate } from "./core/xml.js";
+export { parseGbnf, matchesGbnf, buildGbnfSystemPrompt } from "./core/gbnf.js";
 export { createConversationMemory, COMPLETION_SENTINEL } from "./core/turnaround.js";
 
 export * from "./backends/index.js";
@@ -13,6 +14,7 @@ export type {
   GenerateResult,
   GuaranteeLevel,
   XmlInput,
+  GbnfInput,
   ChatMessage,
   ConversationMemory,
   TurnaroundOptions,

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,17 @@ export type GuaranteeLevel = "constrained" | "native" | "best-effort";
 export type JsonSchemaInput = { jsonSchema: Record<string, unknown> };
 export type PatternInput = { pattern: RegExp };
 export type ValidatorInput = { validate: (output: unknown) => boolean; hint?: Record<string, unknown> };
+export type GbnfInput = {
+  /**
+   * A GBNF (GGML BNF) grammar string. On a llama.cpp-family backend
+   * (`llamaCpp()`) it is applied at the token level, so the output is valid by
+   * construction (`constrained`). On every other backend it is injected into the
+   * prompt (best-effort) and the returned string is validated against the grammar
+   * by a bundled pragmatic GBNF interpreter. Output is always the raw matched
+   * string — never JSON-parsed.
+   */
+  gbnf: string;
+};
 
 export type XmlInput = {
   xml: {
@@ -29,7 +40,7 @@ export type XmlInput = {
 };
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput | XmlInput;
+export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput | XmlInput | GbnfInput;
 
 export interface ChatMessage {
   role: "user" | "assistant";

--- a/tests/gbnf.test.ts
+++ b/tests/gbnf.test.ts
@@ -1,0 +1,335 @@
+import { describe, it, expect } from "vitest";
+import { generate } from "../src/core/generate.js";
+import { generateStream } from "../src/core/stream.js";
+import { matchesGbnf, parseGbnf, buildGbnfSystemPrompt } from "../src/core/gbnf.js";
+import { groq } from "../src/backends/groq.js";
+import { MaxRetriesExceededError } from "../src/types.js";
+import type { ShapecraftModel, StreamEvent } from "../src/types.js";
+import { mockModel } from "./helpers/index.js";
+
+const hasGroq = !!process.env.GROQ_API_KEY;
+
+async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
+  const out: T[] = [];
+  for await (const item of iter) out.push(item);
+  return out;
+}
+
+// ─── The interpreter: parser + matcher ────────────────────────────────────────
+
+describe("GBNF interpreter — matchesGbnf", () => {
+  it("matches an exact string literal", () => {
+    const g = `root ::= "hello"`;
+    expect(matchesGbnf(g, "hello")).toBe(true);
+    expect(matchesGbnf(g, "hi")).toBe(false);
+    expect(matchesGbnf(g, "hello!")).toBe(false); // must consume whole input
+  });
+
+  it("handles alternation", () => {
+    const g = `root ::= "cat" | "dog"`;
+    expect(matchesGbnf(g, "cat")).toBe(true);
+    expect(matchesGbnf(g, "dog")).toBe(true);
+    expect(matchesGbnf(g, "bird")).toBe(false);
+  });
+
+  it("handles sequences and character classes with ranges", () => {
+    const g = `root ::= [0-9] [0-9]`;
+    expect(matchesGbnf(g, "42")).toBe(true);
+    expect(matchesGbnf(g, "4")).toBe(false);
+    expect(matchesGbnf(g, "4a")).toBe(false);
+  });
+
+  it("handles * + ? repetition", () => {
+    expect(matchesGbnf(`root ::= "a"*`, "")).toBe(true);
+    expect(matchesGbnf(`root ::= "a"*`, "aaa")).toBe(true);
+    expect(matchesGbnf(`root ::= "a"+`, "")).toBe(false);
+    expect(matchesGbnf(`root ::= "a"+`, "a")).toBe(true);
+    expect(matchesGbnf(`root ::= "a"? "b"`, "b")).toBe(true);
+    expect(matchesGbnf(`root ::= "a"? "b"`, "ab")).toBe(true);
+    expect(matchesGbnf(`root ::= "a"? "b"`, "aab")).toBe(false);
+  });
+
+  it("handles bounded {m,n} repetition", () => {
+    const g = `root ::= "a"{2,4}`;
+    expect(matchesGbnf(g, "a")).toBe(false);
+    expect(matchesGbnf(g, "aa")).toBe(true);
+    expect(matchesGbnf(g, "aaaa")).toBe(true);
+    expect(matchesGbnf(g, "aaaaa")).toBe(false);
+    expect(matchesGbnf(`root ::= "a"{3}`, "aaa")).toBe(true);
+    expect(matchesGbnf(`root ::= "a"{2,}`, "aaaaa")).toBe(true);
+  });
+
+  it("backtracks through greedy repetition", () => {
+    // requires giving back an 'a' consumed by "a"* so the trailing "a" can match
+    const g = `root ::= "a"* "a"`;
+    expect(matchesGbnf(g, "")).toBe(false);
+    expect(matchesGbnf(g, "a")).toBe(true);
+    expect(matchesGbnf(g, "aaa")).toBe(true);
+  });
+
+  it("handles negated character classes", () => {
+    const g = `root ::= [^0-9]+`;
+    expect(matchesGbnf(g, "abc")).toBe(true);
+    expect(matchesGbnf(g, "ab1")).toBe(false);
+  });
+
+  it("handles rule references and a realistic date grammar", () => {
+    const g = `
+      root  ::= year "-" month "-" day
+      year  ::= [0-9]{4}
+      month ::= [0-9]{2}
+      day   ::= [0-9]{2}
+    `;
+    expect(matchesGbnf(g, "2026-07-06")).toBe(true);
+    expect(matchesGbnf(g, "2026-7-6")).toBe(false);
+    expect(matchesGbnf(g, "not-a-date")).toBe(false);
+  });
+
+  it("handles escapes and quoted content", () => {
+    const g = `root ::= "\\"" [a-z]+ "\\""`;
+    expect(matchesGbnf(g, `"abc"`)).toBe(true);
+    expect(matchesGbnf(g, `abc`)).toBe(false);
+  });
+
+  it("strips # line comments", () => {
+    const g = `
+      # a yes/no grammar
+      root ::= "yes" | "no"  # the two options
+    `;
+    expect(matchesGbnf(g, "yes")).toBe(true);
+    expect(matchesGbnf(g, "maybe")).toBe(false);
+  });
+
+  it("matches a small nested JSON-object grammar", () => {
+    const g = `
+      root   ::= "{" "\\"n\\":" number "}"
+      number ::= "-"? [0-9]+
+    `;
+    expect(matchesGbnf(g, `{"n":42}`)).toBe(true);
+    expect(matchesGbnf(g, `{"n":-7}`)).toBe(true);
+    expect(matchesGbnf(g, `{"n":}`)).toBe(false);
+  });
+
+  it("does not false-negative on the same rule referenced twice at one position", () => {
+    // both `a` can match empty — "" must be accepted (regression guard for the
+    // left-recursion detector being too aggressive)
+    const g = `
+      root ::= a a
+      a    ::= "x"?
+    `;
+    expect(matchesGbnf(g, "")).toBe(true);
+    expect(matchesGbnf(g, "x")).toBe(true);
+    expect(matchesGbnf(g, "xx")).toBe(true);
+    expect(matchesGbnf(g, "xxx")).toBe(false);
+  });
+
+  it("does not hang on a left-recursive grammar", () => {
+    // left recursion is not fully supported, but must terminate (never hang)
+    const g = `root ::= root "a" | "a"`;
+    expect(matchesGbnf(g, "a")).toBe(true);
+    expect(typeof matchesGbnf(g, "aaaa")).toBe("boolean");
+  });
+});
+
+describe("GBNF interpreter — adversarial / pathological grammars (stress)", () => {
+  it("does not exhibit catastrophic backtracking on the classic (a a?)* b trap", () => {
+    // The canonical pattern that blows up naive backtracking regex engines:
+    // ambiguous nested repetition matched against a long string with no valid
+    // terminator. The set-returning matcher dedupes by *position reached*, not
+    // by path taken, so this stays near-linear instead of exponential.
+    const g = `root ::= ("a" "a"?)* "b"`;
+    const t0 = Date.now();
+    expect(matchesGbnf(g, "a".repeat(200))).toBe(false); // no trailing "b" -> no match
+    expect(Date.now() - t0).toBeLessThan(500);
+  });
+
+  it("does not exhibit catastrophic backtracking on ambiguous variable-length alternation", () => {
+    const g = `root ::= item* "X"\nitem ::= [0-9] | [0-9][0-9] | [0-9][0-9][0-9]`;
+    const t0 = Date.now();
+    expect(matchesGbnf(g, "1".repeat(20_000))).toBe(false); // no trailing "X"
+    expect(Date.now() - t0).toBeLessThan(2000);
+  });
+
+  it("matches correctly against a very large input for a simple grammar", () => {
+    expect(matchesGbnf(`root ::= [a-z]+`, "a".repeat(200_000))).toBe(true);
+    expect(matchesGbnf(`root ::= [a-z]+`, "a".repeat(200_000) + "1")).toBe(false);
+  });
+
+  it("handles a large bounded-repetition count correctly at both edges", () => {
+    const g = `root ::= "a"{1,5000}`;
+    expect(matchesGbnf(g, "a".repeat(5000))).toBe(true);
+    expect(matchesGbnf(g, "a".repeat(5001))).toBe(false);
+  });
+
+  it("the step-budget guard trips on a sufficiently extreme grammar, in bounded time, without hanging", () => {
+    // 26-way variable-length ambiguous alternation over a 300k-char input with
+    // a terminator that never appears — genuinely explores enough (position,
+    // rule) combinations to exceed STEP_BUDGET. Proves the safety valve works
+    // (throws a clear message, doesn't hang) rather than merely being untested.
+    const opts = Array.from({ length: 26 }, (_, i) => `"${"x".repeat((i % 5) + 1)}"`).join(" | ");
+    const g = `root ::= item* "END_MARKER_THAT_NEVER_APPEARS"\nitem ::= ${opts}`;
+    const t0 = Date.now();
+    expect(() => matchesGbnf(g, "x".repeat(300_000))).toThrow(/step budget/i);
+    expect(Date.now() - t0).toBeLessThan(5000);
+  });
+
+  it("right-recursive rule REFERENCES (not */+) have a real depth limit — throws a clear, actionable error instead of a raw stack overflow", () => {
+    // Unlike `*`/`+` (iterative BFS, no recursion), a rule reference recurses
+    // through the JS call stack once per repetition. Empirically this breaks
+    // somewhere between depth 900-1000 on this engine/build. Below the limit
+    // it must still work correctly.
+    const g = `root ::= "a" root | ""`;
+    expect(matchesGbnf(g, "a".repeat(500))).toBe(true);
+    expect(() => matchesGbnf(g, "a".repeat(5000))).toThrow(/recursion is too deep/i);
+  });
+
+  it("right-recursion depth limit does not affect the equivalent */+ formulation", () => {
+    // The documented workaround actually works: the same "many a's" language
+    // expressed with `+` instead of recursive references has no depth limit.
+    expect(matchesGbnf(`root ::= "a"+`, "a".repeat(50_000))).toBe(true);
+  });
+});
+
+describe("GBNF interpreter — malformed grammars throw before any model call", () => {
+  it("throws on missing root rule", () => {
+    expect(() => parseGbnf(`start ::= "x"`)).toThrow(/no .root. rule/i);
+  });
+
+  it("throws on unbalanced group", () => {
+    expect(() => parseGbnf(`root ::= ( "a"`)).toThrow(/Invalid GBNF grammar/);
+  });
+
+  it("throws on unterminated string literal", () => {
+    expect(() => parseGbnf(`root ::= "abc`)).toThrow(/Invalid GBNF grammar/);
+  });
+
+  it("buildGbnfSystemPrompt validates the grammar and embeds it", () => {
+    expect(() => buildGbnfSystemPrompt({ gbnf: `root ::= (` })).toThrow(/Invalid GBNF grammar/);
+    const prompt = buildGbnfSystemPrompt({ gbnf: `root ::= "yes" | "no"` });
+    expect(prompt).toContain("GBNF grammar");
+    expect(prompt).toContain(`root ::= "yes" | "no"`);
+  });
+});
+
+// ─── Dispatch integration through generate() ──────────────────────────────────
+
+describe("GBNF input — dispatch through generate()", () => {
+  const dateGrammar = `
+    root  ::= [0-9]{4} "-" [0-9]{2} "-" [0-9]{2}
+  `;
+
+  it("returns the raw conforming string", async () => {
+    const model = mockModel("2026-07-06");
+    const result = await generate(model, { gbnf: dateGrammar }, "today's date");
+    expect(result.data).toBe("2026-07-06");
+    expect(result.attempts).toBe(1);
+  });
+
+  it("returns output as a string, never JSON-parsed", async () => {
+    const model = mockModel("42");
+    const result = await generate(model, { gbnf: `root ::= [0-9]+` }, "a number");
+    expect(result.data).toBe("42"); // string "42", not number 42
+    expect(typeof result.data).toBe("string");
+  });
+
+  it("retries and throws MaxRetriesExceededError on non-conforming output", async () => {
+    const model = mockModel("not-a-date");
+    await expect(
+      generate(model, { gbnf: dateGrammar }, "today's date", { maxRetries: 2 })
+    ).rejects.toBeInstanceOf(MaxRetriesExceededError);
+  });
+
+  it("propagates a malformed-grammar error without retrying", async () => {
+    // A grammar bug is a programmer error — it should surface immediately as a
+    // plain Error, not be retried into MaxRetriesExceededError.
+    const model = mockModel("anything");
+    await expect(
+      generate(model, { gbnf: `root ::= (` }, "x", { maxRetries: 3 })
+    ).rejects.toThrow(/Invalid GBNF grammar/);
+  });
+});
+
+// ─── Streaming: delta/done only, never partial ────────────────────────────────
+
+describe("GBNF input — streaming emits no per-field partials", () => {
+  function mockStreamingModel(chunks: string[]): ShapecraftModel {
+    return {
+      id: "mock:gbnf-stream",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        throw new Error("generate() should not be called in these tests");
+      },
+      async *generateStream(): AsyncIterable<string> {
+        for (const c of chunks) yield c;
+      },
+    } as ShapecraftModel;
+  }
+
+  it("emits delta/done but no partial, even for a JSON-shaped grammar", async () => {
+    // Grammar produces a JSON object — proves the incremental field scanner is
+    // suppressed for gbnf (it would otherwise emit misleading `partial` events).
+    const g = `
+      root   ::= "{" "\\"n\\":" number "}"
+      number ::= [0-9]+
+    `;
+    const model = mockStreamingModel(['{"n":', "4", "2}"]);
+    const stream = generateStream(model, { gbnf: g }, "make an object");
+
+    const [events, result] = await Promise.all([
+      collect(stream.events),
+      stream.result,
+    ]);
+
+    const types = events.map((e: StreamEvent<unknown>) => e.type);
+    expect(types).toContain("delta");
+    expect(types).toContain("done");
+    expect(types).not.toContain("partial");
+    expect(result.data).toBe('{"n":42}');
+  });
+});
+
+// ─── Real backend: Groq (skip-gated) ──────────────────────────────────────────
+// Regression guard: groq() must NOT force response_format: json_object for a
+// gbnf input — the grammar's output is a free-form string, and Groq's API
+// rejects json_object mode outright when the prompt doesn't contain the word
+// "json" (a 400, not a validation failure). Caught by exercising the real API
+// through the test-repo's /gbnf endpoint; XML already had this guard, gbnf
+// (added on both generate() and generateStream()) initially didn't.
+describe("GBNF input — Groq backend (real API)", () => {
+  it.skipIf(!hasGroq)("does not force json_object mode, so a plain-string grammar succeeds", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const result = await generate(
+      model,
+      { gbnf: `root ::= "positive" | "negative" | "neutral"` },
+      "Classify the sentiment: 'This is the best purchase I've made all year!'"
+    );
+    expect(["positive", "negative", "neutral"]).toContain(result.data);
+  }, 30_000);
+
+  it.skipIf(!hasGroq)("streaming does not force json_object mode either", async () => {
+    const model = groq({ model: "llama-3.3-70b-versatile" });
+    const stream = generateStream(model, { gbnf: `root ::= "positive" | "negative" | "neutral"` }, "Classify: 'I love it!'");
+    const result = await stream.result;
+    expect(["positive", "negative", "neutral"]).toContain(result.data);
+  }, 30_000);
+});
+
+// ─── Real backend: llamaCpp (skip-gated on a local model) ─────────────────────
+
+const MODEL_PATH = process.env.LLAMACPP_MODEL_PATH;
+const describeLlama = MODEL_PATH ? describe : describe.skip;
+
+describeLlama("GBNF input — llamaCpp() token-level constraint", () => {
+  it("produces grammar-conforming output with a constrained guarantee", async () => {
+    const { llamaCpp } = await import("../src/backends/llamaCpp.js");
+    const model = llamaCpp({ modelPath: MODEL_PATH! });
+    const grammar = `root ::= "positive" | "negative" | "neutral"`;
+    const result = await generate(
+      model,
+      { gbnf: grammar },
+      "Classify the sentiment of: 'I absolutely love this product!'"
+    );
+    expect(["positive", "negative", "neutral"]).toContain(result.data);
+    expect(result.guaranteeLevel).toBe("constrained");
+  }, 120_000);
+});


### PR DESCRIPTION
## Summary
- Adds `generate(model, { gbnf: grammarString }, prompt)` - a raw GBNF grammar SchemaInput.
  Output is the raw string that conforms to the grammar.
- Adds `llamaCpp()` backend (node-llama-cpp) - applies the grammar at the token level, so
  output is valid by construction (`constrained`), not just prompted-and-checked.
- Bundles a pragmatic GBNF interpreter (`matchesGbnf`, `parseGbnf`, `buildGbnfSystemPrompt`,
  all exported) for every other backend - validates grammar output after the fact, and fails
  fast on a malformed grammar before any model call.
- Streaming for `{ gbnf }` emits `delta`/`done` only (no per-field `partial`, since it's not
  field-decomposable like JSON).

## Fixed
- `groq()` no longer forces `response_format: json_object` for `{ gbnf }` inputs (it already
  skipped this for `{ xml }`, but not `gbnf`) - Groq's API rejects json_object mode outright
  when the prompt doesn't contain the word "json", which broke every gbnf call on this backend.
  Fixed in both `generate()` and `generateStream()`.
- `matchesGbnf` throws a clear, actionable error ("recursion is too deep... prefer `*`/`+`")
  when a deeply right-recursive rule reference exceeds the JS call stack (~900-1000
  repetitions empirically), instead of letting a raw stack-overflow `RangeError` propagate.
- Version bump to 2.2.0 (minor - real new feature).