### PR TITLE
feat(fhir): add Extension support across all R4 presets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [2.3.0] - 2026-07-16
+
+### Added
+
+- **FHIR `Extension` support** - every R4 preset (`Patient`, `Observation`, `Condition`,
+  `MedicationRequest`, `Encounter`) now accepts an optional `extension?: Extension[]`. Common-
+  subset `Extension` type covers `url` plus `valueString`/`valueInteger`/`valueBoolean`/
+  `valueCodeableConcept` - real FHIR's `value[x]` has ~20 polymorphic variants; unsupported
+  ones pass through unvalidated (no `oneOf` support in `checkJsonSchema`) rather than being
+  rejected.
+
 ## [2.2.0] - 2026-07-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -595,10 +595,19 @@ const { data } = await generate(
 
 Five R4 resources are included: **`Patient`**, **`Observation`**, **`Condition`**, **`MedicationRequest`**, **`Encounter`**. Each models a practical common subset (not every field the spec allows) and enforces the required-bound value-set enums (`gender`, `status`, `intent`, …). Because they're JSON-object schemas, streaming `partial` events validate each top-level field as it arrives, for free.
 
+Every preset also accepts an optional `extension?: Extension[]` (FHIR's mechanism for custom/local fields not in the base spec):
+
+```typescript
+const { data } = await generate(model, fhir.Patient, "...", { /* ... */ });
+// data.extension: [{ url: "https://hospital-a.example.com/fhir/.../preferred-pharmacy", valueString: "Walgreens #4521" }]
+```
+
+`Extension` is a common-subset type too — `url` plus one of `valueString` / `valueInteger` / `valueBoolean` / `valueCodeableConcept` (real FHIR's `value[x]` has ~20 polymorphic variants; unsupported ones pass through unvalidated rather than being rejected, since `checkJsonSchema` has no `oneOf`).
+
 Two things worth knowing before you rely on them:
 
 - **`required` is opinionated, not FHIR cardinality.** FHIR marks almost nothing mandatory (a `Patient` with no name is technically valid FHIR). These presets require a *useful* minimum for extraction (e.g. `Patient` requires name + gender + birthDate). Where FHIR genuinely mandates a field (`Observation.status`/`code`, `MedicationRequest.status`/`intent`/`subject`), that's mirrored exactly.
-- **Structural, not clinical.** A preset guarantees the resource is well-formed and required-fields-complete. It does **not** verify terminology codes (LOINC/SNOMED/RxNorm membership is not checked — a `Coding` is validated as having `system`/`code` strings, not as a real code), date formats, choice-type polymorphism (each preset commits to one `value[x]`/`medication[x]` variant), or any clinical invariant. **A structurally-valid FHIR resource is not the same as a correct or safe-to-act-on one** — see the guarantees note directly below.
+- **Structural, not clinical.** A preset guarantees the resource is well-formed and required-fields-complete. It does **not** verify terminology codes (LOINC/SNOMED/RxNorm membership is not checked — a `Coding` is validated as having `system`/`code` strings, not as a real code), date formats, choice-type polymorphism (each preset commits to one `medication[x]` variant, and `Extension` covers only its four most common `value[x]` variants), or any clinical invariant. **A structurally-valid FHIR resource is not the same as a correct or safe-to-act-on one** — see the guarantees note directly below.
 
 ## What shapecraft guarantees — and what it doesn't
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/fhir/condition.ts
+++ b/src/fhir/condition.ts
@@ -1,8 +1,10 @@
 import type { SchemaInput } from "../types.js";
 import {
   codeableConceptSchema,
+  extensionSchema,
   referenceSchema,
   type CodeableConcept,
+  type Extension,
   type Reference,
 } from "./types.js";
 
@@ -24,6 +26,7 @@ export interface Condition {
   subject: Reference;
   onsetDateTime?: string;
   recordedDate?: string;
+  extension?: Extension[];
 }
 
 const ConditionJsonSchema = {
@@ -38,6 +41,7 @@ const ConditionJsonSchema = {
     subject: referenceSchema,
     onsetDateTime: { type: "string" },
     recordedDate: { type: "string" },
+    extension: { type: "array", items: extensionSchema },
   },
 };
 

--- a/src/fhir/encounter.ts
+++ b/src/fhir/encounter.ts
@@ -2,10 +2,12 @@ import type { SchemaInput } from "../types.js";
 import {
   codeableConceptSchema,
   codingSchema,
+  extensionSchema,
   periodSchema,
   referenceSchema,
   type CodeableConcept,
   type Coding,
+  type Extension,
   type Period,
   type Reference,
 } from "./types.js";
@@ -34,6 +36,7 @@ export interface Encounter {
   subject?: Reference;
   period?: Period;
   reasonCode?: CodeableConcept[];
+  extension?: Extension[];
 }
 
 const EncounterJsonSchema = {
@@ -60,6 +63,7 @@ const EncounterJsonSchema = {
     subject: referenceSchema,
     period: periodSchema,
     reasonCode: { type: "array", items: codeableConceptSchema },
+    extension: { type: "array", items: extensionSchema },
   },
 };
 

--- a/src/fhir/index.ts
+++ b/src/fhir/index.ts
@@ -41,4 +41,5 @@ export type {
   Period,
   Quantity,
   Identifier,
+  Extension,
 } from "./types.js";

--- a/src/fhir/medication-request.ts
+++ b/src/fhir/medication-request.ts
@@ -1,8 +1,10 @@
 import type { SchemaInput } from "../types.js";
 import {
   codeableConceptSchema,
+  extensionSchema,
   referenceSchema,
   type CodeableConcept,
+  type Extension,
   type Reference,
 } from "./types.js";
 
@@ -39,6 +41,7 @@ export interface MedicationRequest {
   authoredOn?: string;
   requester?: Reference;
   dosageInstruction?: { text?: string }[];
+  extension?: Extension[];
 }
 
 const MedicationRequestJsonSchema = {
@@ -83,6 +86,7 @@ const MedicationRequestJsonSchema = {
         properties: { text: { type: "string" } },
       },
     },
+    extension: { type: "array", items: extensionSchema },
   },
 };
 

--- a/src/fhir/observation.ts
+++ b/src/fhir/observation.ts
@@ -1,9 +1,11 @@
 import type { SchemaInput } from "../types.js";
 import {
   codeableConceptSchema,
+  extensionSchema,
   quantitySchema,
   referenceSchema,
   type CodeableConcept,
+  type Extension,
   type Quantity,
   type Reference,
 } from "./types.js";
@@ -33,6 +35,7 @@ export interface Observation {
   subject?: Reference;
   effectiveDateTime?: string;
   valueQuantity?: Quantity;
+  extension?: Extension[];
 }
 
 const ObservationJsonSchema = {
@@ -58,6 +61,7 @@ const ObservationJsonSchema = {
     subject: referenceSchema,
     effectiveDateTime: { type: "string" },
     valueQuantity: quantitySchema,
+    extension: { type: "array", items: extensionSchema },
   },
 };
 

--- a/src/fhir/patient.ts
+++ b/src/fhir/patient.ts
@@ -2,10 +2,12 @@ import type { SchemaInput } from "../types.js";
 import {
   addressSchema,
   contactPointSchema,
+  extensionSchema,
   humanNameSchema,
   identifierSchema,
   type Address,
   type ContactPoint,
+  type Extension,
   type HumanName,
   type Identifier,
 } from "./types.js";
@@ -27,6 +29,7 @@ export interface Patient {
   birthDate: string; // YYYY-MM-DD — validated as string only, not date format
   telecom?: ContactPoint[];
   address?: Address[];
+  extension?: Extension[];
 }
 
 const PatientJsonSchema = {
@@ -41,6 +44,7 @@ const PatientJsonSchema = {
     birthDate: { type: "string" },
     telecom: { type: "array", items: contactPointSchema },
     address: { type: "array", items: addressSchema },
+    extension: { type: "array", items: extensionSchema },
   },
 };
 

--- a/src/fhir/types.ts
+++ b/src/fhir/types.ts
@@ -64,6 +64,22 @@ export interface Identifier {
   value?: string;
 }
 
+/**
+ * FHIR R4 Extension (common subset).
+ *
+ * Real FHIR `value[x]` has ~20 polymorphic variants. This preset covers the
+ * four most common (string/integer/boolean/CodeableConcept) — `checkJsonSchema`
+ * has no `oneOf`, so unsupported variants pass through unvalidated rather than
+ * being rejected. Add more `value*` fields here if a rarer variant is needed.
+ */
+export interface Extension {
+  url: string;
+  valueString?: string;
+  valueInteger?: number;
+  valueBoolean?: boolean;
+  valueCodeableConcept?: CodeableConcept;
+}
+
 // ── JSON Schema fragments (embedded by the resource presets) ─────────────────
 
 export const codingSchema = {
@@ -146,5 +162,17 @@ export const identifierSchema = {
   properties: {
     system: { type: "string" },
     value: { type: "string" },
+  },
+};
+
+export const extensionSchema = {
+  type: "object",
+  required: ["url"],
+  properties: {
+    url: { type: "string" },
+    valueString: { type: "string" },
+    valueInteger: { type: "number" },
+    valueBoolean: { type: "boolean" },
+    valueCodeableConcept: codeableConceptSchema,
   },
 };

--- a/tests/fhir.test.ts
+++ b/tests/fhir.test.ts
@@ -148,6 +148,30 @@ describe("fhir presets", () => {
     expect(data).toEqual({ count: 0, active: false });
   });
 
+  it("validates a Patient carrying a custom extension", async () => {
+    const withExtension = {
+      ...validPatient,
+      extension: [
+        {
+          url: "https://hospital-a.example.com/fhir/StructureDefinition/preferred-pharmacy",
+          valueString: "Walgreens #4521",
+        },
+      ],
+    };
+    const { data } = await generate(fixedModel(withExtension), fhir.Patient, "extract patient");
+    expect(data).toEqual(withExtension);
+  });
+
+  it("rejects an extension missing its required url", async () => {
+    const badExtension = {
+      ...validPatient,
+      extension: [{ valueString: "no url here" }],
+    };
+    await expect(
+      generate(fixedModel(badExtension), fhir.Patient, "extract patient", { maxRetries: 1 })
+    ).rejects.toBeInstanceOf(Error);
+  });
+
   it("emits per-field partial events streaming a Patient", async () => {
     const model = streamingModel(JSON.stringify(validPatient));
     const stream = generateStream(model, fhir.Patient, "extract patient");


### PR DESCRIPTION
- Adds a common-subset `Extension` type (`url` plus `valueString` / `valueInteger` /
  `valueBoolean` / `valueCodeableConcept`), covering the four most common `value[x]`
  variants of FHIR's ~20 polymorphic options
- Wires an optional `extension?: Extension[]` field into all five R4 presets: `Patient`,
  `Observation`, `Condition`, `MedicationRequest`, `Encounter`
- Unsupported `value[x]` variants pass through unvalidated rather than being rejected,
  since the built-in `checkJsonSchema` has no `oneOf` support
- Adds positive and negative test coverage (valid extension accepted, extension missing
  its required `url` rejected)
- Updates the README FHIR presets section to document `extension` usage and corrects the
  choice-type-polymorphism note to reflect `Extension`'s four supported variants
- Bumps package version to 2.3.0 with a matching CHANGELOG entry
