### PR TITLE
feat: add fireworks(), mistral(), openRouter(), gemini(), deepseek() backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@
     applied server-side - not the prompted-and-checked best-effort path every other cloud
     backend falls back to for gbnf. It's the same real guarantee `llamaCpp()` gives
     locally, just without needing a local `.gguf` file.
+- **`mistral()` backend** - Mistral AI, same `openai`-package-pointed-at-a-different-base-URL
+  approach as `fireworks()`. `guaranteeLevel: "native"` - `response_format: { type:
+  "json_schema", ... }` is server-side enforced, same tier as `openai()`/`groq()`/
+  `fireworks()`. No grammar mode - a `{ gbnf }` input is prompt-only, best-effort, same
+  as `openai()`/`groq()`.
 
 ## [2.4.0] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [2.5.0] - 2026-07-15
+
+### Added
+
+- **`fireworks()` backend** - Fireworks AI, reached via the `openai` package pointed at
+  Fireworks' base URL (no new SDK dependency). `guaranteeLevel: "native"` - JSON/Zod
+  schemas use Fireworks' server-side JSON schema mode, same tier as `openai()`/`groq()`.
+  - The differentiator: a `{ gbnf }` input gets Fireworks' own grammar mode
+    (`response_format: { type: "grammar", grammar }`), a genuine token-level constraint
+    applied server-side - not the prompted-and-checked best-effort path every other cloud
+    backend falls back to for gbnf. It's the same real guarantee `llamaCpp()` gives
+    locally, just without needing a local `.gguf` file.
+
 ## [2.4.0] - 2026-07-17
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@
   is server-side constrained decoding, same tier as `openai()`/`groq()`/`fireworks()`/
   `mistral()`. No grammar mode - a `{ gbnf }` input is prompt-only, best-effort, same as
   every other backend without one.
+- **`deepseek()` backend** - DeepSeek, reached via the `openai` package pointed at DeepSeek's
+  base URL (no new SDK dependency, same approach as `fireworks()`/`mistral()`/`openRouter()`).
+  `guaranteeLevel: "native"` - `response_format: { type: "json_object" }` is a real,
+  server-side JSON-mode toggle, same tier as `groq()` - but unlike `fireworks()`/`mistral()`,
+  DeepSeek's API only supports `"json_object"` (valid JSON), not a schema-strict
+  `"json_schema"` mode. Requires the literal word "json" in the prompt for `json_object`
+  mode to behave, same restriction as `groq()`. No grammar mode - a `{ gbnf }` input is
+  prompt-only, best-effort, same as every other backend without one. Defaults to
+  `deepseek-v4-flash` - `deepseek-chat`/`deepseek-reasoner` are deprecated 2026-07-24 in
+  favor of `deepseek-v4-flash` (non-thinking) / `deepseek-v4-pro` (thinking).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,25 @@
   "json_schema", ... }` is server-side enforced, same tier as `openai()`/`groq()`/
   `fireworks()`. No grammar mode - a `{ gbnf }` input is prompt-only, best-effort, same
   as `openai()`/`groq()`.
+- **`openRouter()` backend** - same `openai`-package-pointed-at-a-different-base-URL
+  approach as `fireworks()`/`mistral()`. `guaranteeLevel: "best-effort"`, deliberately
+  not `"native"` like the other cloud backends - OpenRouter is pass-through across many
+  different underlying providers/models, and `response_format: { type: "json_schema" }`
+  enforcement isn't guaranteed for every model it can route to. Defensively requests
+  `extractJson: true` on every call for the same reason `anthropic()` needs it. No
+  grammar mode - a `{ gbnf }` input is prompt-only, best-effort.
+
+### Fixed
+
+- **`toJsonSchema()` emitted the legacy OpenAPI 3.0 boolean form for exclusive bounds**
+  (`.positive()`/`.negative()`/`.gt()`/`.lt()`) - `exclusiveMinimum: true` + a separate
+  `minimum`, instead of the numeric form real JSON Schema requires (`exclusiveMinimum: 0`).
+  Backends that validate the schema itself strictly (confirmed on Mistral, which rejected
+  it outright with a 422) reject the boolean form before the model ever runs. Switched
+  `zodToJsonSchema`'s target from `openApi3` to `jsonSchema7` (stripping the extraneous
+  `$schema` key it adds). Affects every backend's Zod-schema handling, not just Mistral -
+  verified live against `groq()`, `anthropic()`, and `ollama()` with the schema that broke
+  Mistral.
 
 ## [2.4.0] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@
   enforcement isn't guaranteed for every model it can route to. Defensively requests
   `extractJson: true` on every call for the same reason `anthropic()` needs it. No
   grammar mode - a `{ gbnf }` input is prompt-only, best-effort.
+- **`gemini()` backend** - Google Gemini, via the official `@google/genai` SDK rather
+  than `openai`-pointed-at-a-different-base-URL - Gemini's OpenAI-compatible endpoint is
+  a migration bridge for OpenAI users, not its primary integration path, and doesn't
+  expose `responseJsonSchema` (plain JSON Schema, what `toJsonSchema()` already produces)
+  - only the older `responseSchema` (Gemini's own Type-enum OpenAPI-subset shape).
+  `guaranteeLevel: "native"` - `responseJsonSchema`/`responseMimeType: "application/json"`
+  is server-side constrained decoding, same tier as `openai()`/`groq()`/`fireworks()`/
+  `mistral()`. No grammar mode - a `{ gbnf }` input is prompt-only, best-effort, same as
+  every other backend without one.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Structured output generation for LLMs in Node.js. Token-level constraints for lo
 
 ```bash
 npm install @aviasole/shapecraft zod
+# or: pnpm add @aviasole/shapecraft zod
 ```
 
 Install backend SDK as needed:

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ conforming string can still be a wrong answer (see
 > only the older `responseSchema` (Gemini's own Type-enum OpenAPI-subset shape).
 
 ```typescript
-import { openai, groq, fireworks, mistral, gemini, openRouter, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
+import { openai, groq, fireworks, mistral, gemini, openRouter, deepseek, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
 
 const gpt       = openai({ model: "gpt-4o-mini" });
 const fast      = groq({ model: "llama-3.3-70b-versatile" });
@@ -353,6 +353,7 @@ const cloudGbnf = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-i
 const mist      = mistral({ model: "mistral-large-latest" });
 const gem       = gemini({ model: "gemini-flash-latest" });
 const router    = openRouter({ model: "openai/gpt-4o-mini" });
+const deep      = deepseek({ model: "deepseek-v4-flash" });
 const local     = ollama({ model: "llama3.2" });
 const native    = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });
 const claude    = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
@@ -364,7 +365,7 @@ Every built-in backend also exposes `capabilities` — an explicit, inspectable 
 
 ```typescript
 console.log(claude.capabilities);
-// { streaming: true, chat: true, structuredOutput: true, toolCalling: false }
+// { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true }
 ```
 
 ```typescript
@@ -373,6 +374,7 @@ interface ModelCapabilities {
   chat: boolean;            // has chat() - required for turnaround: true
   structuredOutput: boolean; // has generate() - always true
   toolCalling: boolean;     // not yet supported by any backend
+  skillDispatch: boolean;   // generateSkillCall()/runSkillLoop() - always true, built on generate()
 }
 ```
 
@@ -384,7 +386,7 @@ Other libraries solve overlapping parts of this problem well. This is what's act
 
 | Capability | Instructor-js | zod-gpt | Vercel AI SDK (`generateObject`) | shapecraft |
 |---|---|---|---|---|
-| Providers | OpenAI only | OpenAI, Anthropic | OpenAI, Anthropic, Google, and more | OpenAI, Groq, Anthropic, Ollama |
+| Providers | OpenAI only | OpenAI, Anthropic | OpenAI, Anthropic, Google, and more | OpenAI, Groq, Anthropic, Ollama, and many more |
 | Local model support | - | - | no grammar-level constraint | Ollama with token-level GBNF grammar |
 | Per-provider reliability signal | - | - | - | `guaranteeLevel`: `native` / `constrained` / `best-effort` |
 | Retry on schema failure | not documented | fixed 3 attempts, 60s timeout | configurable `maxRetries` | configurable, only on schema-validation failure |

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ conforming string can still be a wrong answer (see
 | `ollama()` | `constrained` | Token-level JSON-schema constraint |
 | `llamaCpp()` | `constrained` | Token-level GBNF grammar (local `.gguf` via node-llama-cpp) |
 | `anthropic()` | `best-effort` | Prompt + parse + retry |
+| `openRouter()` | `best-effort` | Pass-through to many providers - `response_format` support varies by underlying model |
 
 > `llamaCpp()` is `constrained` for a `{ gbnf }` input (token-level). For other schema
 > types (Zod / jsonSchema / …) it currently runs a best-effort prompt path until the
@@ -328,14 +329,20 @@ conforming string can still be a wrong answer (see
 > applies the GBNF grammar as a genuine token-level constraint server-side, the same
 > guarantee `llamaCpp()` gives locally. It reuses the `openai` package pointed at
 > Fireworks' base URL, so no extra SDK dependency is needed.
+>
+> `openRouter()` is deliberately `best-effort`, not `native` like the other cloud
+> backends — it's pass-through across many different underlying providers/models, and
+> `response_format: { type: "json_schema" }` enforcement isn't guaranteed for every model
+> it can route to, only the ones that actually support it themselves.
 
 ```typescript
-import { openai, groq, fireworks, mistral, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
+import { openai, groq, fireworks, mistral, openRouter, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
 
 const gpt       = openai({ model: "gpt-4o-mini" });
 const fast      = groq({ model: "llama-3.3-70b-versatile" });
 const cloudGbnf = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" });
 const mist      = mistral({ model: "mistral-large-latest" });
+const router    = openRouter({ model: "openai/gpt-4o-mini" });
 const local     = ollama({ model: "llama3.2" });
 const native    = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });
 const claude    = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });

--- a/README.md
+++ b/README.md
@@ -314,6 +314,7 @@ conforming string can still be a wrong answer (see
 | `openai()` | `native` | Server-side strict JSON schema |
 | `groq()` | `native` | JSON mode |
 | `fireworks()` | `native` | Server-side JSON schema mode, plus a real token-level GBNF grammar mode |
+| `mistral()` | `native` | Server-side JSON schema mode |
 | `ollama()` | `constrained` | Token-level JSON-schema constraint |
 | `llamaCpp()` | `constrained` | Token-level GBNF grammar (local `.gguf` via node-llama-cpp) |
 | `anthropic()` | `best-effort` | Prompt + parse + retry |
@@ -329,14 +330,15 @@ conforming string can still be a wrong answer (see
 > Fireworks' base URL, so no extra SDK dependency is needed.
 
 ```typescript
-import { openai, groq, fireworks, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
+import { openai, groq, fireworks, mistral, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
 
-const gpt      = openai({ model: "gpt-4o-mini" });
-const fast     = groq({ model: "llama-3.3-70b-versatile" });
+const gpt       = openai({ model: "gpt-4o-mini" });
+const fast      = groq({ model: "llama-3.3-70b-versatile" });
 const cloudGbnf = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" });
-const local    = ollama({ model: "llama3.2" });
-const native   = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });
-const claude   = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
+const mist      = mistral({ model: "mistral-large-latest" });
+const local     = ollama({ model: "llama3.2" });
+const native    = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });
+const claude    = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
 ```
 
 ### Model Capabilities

--- a/README.md
+++ b/README.md
@@ -669,6 +669,66 @@ try {
 
 A handler that throws — including the terminal skill's own handler — doesn't abort the loop. It's recorded as an error turn and fed back to the model, which can adapt (different arguments, a different skill, or try again) on the next turn. The loop only ever exits early via a thrown `MaxSkillTurnsExceededError`; a successful terminal-skill call is the only path to `{ status: "complete" }`.
 
+## Skill-Based Generation
+
+Let the model pick which of several typed operations to run, with validated arguments — instead of always extracting one fixed shape. Register a set of skills (name, Zod input schema, handler function), and `generateSkillCall()` dispatches to the right one:
+
+```typescript
+import { z } from "zod";
+import { SkillRegistry, generateSkillCall, runSkill } from "@aviasole/shapecraft";
+
+const registry = new SkillRegistry();
+
+registry.register({
+  name: "lookupOrder",
+  description: "Look up an order's status by its order ID",
+  inputSchema: z.object({ orderId: z.string() }),
+  handler: async ({ orderId }) => db.orders.findById(orderId),
+});
+
+registry.register({
+  name: "sendRefund",
+  inputSchema: z.object({ orderId: z.string(), amount: z.number() }),
+  handler: async ({ orderId, amount }) => paymentsApi.refund(orderId, amount),
+});
+
+const call = await generateSkillCall(model, registry, "What's the status of order #4521?");
+// { skill: "lookupOrder", args: { orderId: "4521" } }
+
+const result = await runSkill(registry, call);
+```
+
+`generateSkillCall()` is a thin wrapper around `generate()` — it builds a `z.discriminatedUnion` over every registered skill's `inputSchema` and dispatches through the same retry loop, so `guaranteeLevel` semantics (native/constrained/best-effort) apply per backend exactly like any other call. This is deliberately **not** built on OpenAI/Anthropic's native tool-calling APIs — those don't exist on Ollama or `llamaCpp()` at all, so schema-based dispatch is what makes tool use work identically across every backend, local models included.
+
+v1 skill schemas are **Zod only** — that's the mechanism that makes the discriminated-union dispatch work with zero new validation code.
+
+### Looping toward a goal
+
+`runSkillLoop()` repeatedly picks and runs a skill, feeding each result back as context, until a skill marked `terminal: true` succeeds or `maxTurns` is hit:
+
+```typescript
+import { runSkillLoop, MaxSkillTurnsExceededError } from "@aviasole/shapecraft";
+
+registry.register({
+  name: "sendRefund",
+  inputSchema: z.object({ orderId: z.string(), amount: z.number() }),
+  handler: async ({ orderId, amount }) => paymentsApi.refund(orderId, amount),
+  terminal: true, // running this successfully ends the loop
+});
+
+try {
+  const { result, memory } = await runSkillLoop(model, registry, "Refund order #4521");
+  console.log(result); // whatever the terminal skill's handler returned
+} catch (err) {
+  if (err instanceof MaxSkillTurnsExceededError) {
+    // err.memory is JSON-serializable — persist it and call runSkillLoop() again
+    // with a fresh maxTurns budget (and { memory: err.memory }) to continue.
+  }
+}
+```
+
+A handler that throws — including the terminal skill's own handler — doesn't abort the loop. It's recorded as an error turn and fed back to the model, which can adapt (different arguments, a different skill, or try again) on the next turn. The loop only ever exits early via a thrown `MaxSkillTurnsExceededError`; a successful terminal-skill call is the only path to `{ status: "complete" }`.
+
 ## What shapecraft guarantees — and what it doesn't
 
 Every mechanism above (`native`, `constrained`, `best-effort` + retry) targets one thing: **the output is structurally valid** — it parses, the types match, required fields are present and non-empty. That's a real, load-bearing guarantee: it's the difference between code that can trust `result.data.age` is a `number` versus code that has to defensively re-check everything the model says.

--- a/README.md
+++ b/README.md
@@ -313,6 +313,7 @@ conforming string can still be a wrong answer (see
 |---|---|---|
 | `openai()` | `native` | Server-side strict JSON schema |
 | `groq()` | `native` | JSON mode |
+| `fireworks()` | `native` | Server-side JSON schema mode, plus a real token-level GBNF grammar mode |
 | `ollama()` | `constrained` | Token-level JSON-schema constraint |
 | `llamaCpp()` | `constrained` | Token-level GBNF grammar (local `.gguf` via node-llama-cpp) |
 | `anthropic()` | `best-effort` | Prompt + parse + retry |
@@ -320,15 +321,22 @@ conforming string can still be a wrong answer (see
 > `llamaCpp()` is `constrained` for a `{ gbnf }` input (token-level). For other schema
 > types (Zod / jsonSchema / …) it currently runs a best-effort prompt path until the
 > JSON-Schema→GBNF converter lands — treat those as best-effort despite the nominal level.
+>
+> `fireworks()` is the one cloud backend where a `{ gbnf }` input is *not* downgraded to
+> best-effort — Fireworks' grammar mode (`response_format: { type: "grammar", grammar }`)
+> applies the GBNF grammar as a genuine token-level constraint server-side, the same
+> guarantee `llamaCpp()` gives locally. It reuses the `openai` package pointed at
+> Fireworks' base URL, so no extra SDK dependency is needed.
 
 ```typescript
-import { openai, groq, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
+import { openai, groq, fireworks, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
 
-const gpt    = openai({ model: "gpt-4o-mini" });
-const fast   = groq({ model: "llama-3.3-70b-versatile" });
-const local  = ollama({ model: "llama3.2" });
-const native = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });
-const claude = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
+const gpt      = openai({ model: "gpt-4o-mini" });
+const fast     = groq({ model: "llama-3.3-70b-versatile" });
+const cloudGbnf = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" });
+const local    = ollama({ model: "llama3.2" });
+const native   = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });
+const claude   = anthropic({ model: "claude-haiku-4-5-20251001", maxRetries: 3 });
 ```
 
 ### Model Capabilities

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ npm install @aviasole/shapecraft zod
 Install backend SDK as needed:
 
 ```bash
-npm install openai              # OpenAI
+npm install openai              # OpenAI, Fireworks, Mistral, OpenRouter (all OpenAI-compatible)
 npm install groq-sdk            # Groq
 npm install @anthropic-ai/sdk   # Anthropic
+npm install @google/genai       # Gemini
 # Ollama: no extra SDK needed
 ```
 
@@ -315,6 +316,7 @@ conforming string can still be a wrong answer (see
 | `groq()` | `native` | JSON mode |
 | `fireworks()` | `native` | Server-side JSON schema mode, plus a real token-level GBNF grammar mode |
 | `mistral()` | `native` | Server-side JSON schema mode |
+| `gemini()` | `native` | Server-side JSON schema mode (`responseJsonSchema`) |
 | `ollama()` | `constrained` | Token-level JSON-schema constraint |
 | `llamaCpp()` | `constrained` | Token-level GBNF grammar (local `.gguf` via node-llama-cpp) |
 | `anthropic()` | `best-effort` | Prompt + parse + retry |
@@ -334,14 +336,21 @@ conforming string can still be a wrong answer (see
 > backends — it's pass-through across many different underlying providers/models, and
 > `response_format: { type: "json_schema" }` enforcement isn't guaranteed for every model
 > it can route to, only the ones that actually support it themselves.
+>
+> `gemini()` uses the official `@google/genai` SDK, not an OpenAI-compatible endpoint
+> (unlike `fireworks()`/`mistral()`/`openRouter()`) — Gemini's OpenAI-compat layer is a
+> migration bridge for OpenAI users, not its primary integration path, and doesn't expose
+> `responseJsonSchema` (plain JSON Schema, what `toJsonSchema()` already produces) —
+> only the older `responseSchema` (Gemini's own Type-enum OpenAPI-subset shape).
 
 ```typescript
-import { openai, groq, fireworks, mistral, openRouter, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
+import { openai, groq, fireworks, mistral, gemini, openRouter, ollama, anthropic, llamaCpp } from "@aviasole/shapecraft";
 
 const gpt       = openai({ model: "gpt-4o-mini" });
 const fast      = groq({ model: "llama-3.3-70b-versatile" });
 const cloudGbnf = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" });
 const mist      = mistral({ model: "mistral-large-latest" });
+const gem       = gemini({ model: "gemini-flash-latest" });
 const router    = openRouter({ model: "openai/gpt-4o-mini" });
 const local     = ollama({ model: "llama3.2" });
 const native    = llamaCpp({ modelPath: "./models/llama-3.2-3b.gguf" });

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ npm install @aviasole/shapecraft zod
 Install backend SDK as needed:
 
 ```bash
-npm install openai              # OpenAI, Fireworks, Mistral, OpenRouter (all OpenAI-compatible)
+npm install openai              # OpenAI, Fireworks, Mistral, OpenRouter, DeepSeek (all OpenAI-compatible)
 npm install groq-sdk            # Groq
 npm install @anthropic-ai/sdk   # Anthropic
 npm install @google/genai       # Gemini
@@ -314,6 +314,7 @@ conforming string can still be a wrong answer (see
 |---|---|---|
 | `openai()` | `native` | Server-side strict JSON schema |
 | `groq()` | `native` | JSON mode |
+| `deepseek()` | `native` | JSON mode (no schema-strict mode, same tier as `groq()`) |
 | `fireworks()` | `native` | Server-side JSON schema mode, plus a real token-level GBNF grammar mode |
 | `mistral()` | `native` | Server-side JSON schema mode |
 | `gemini()` | `native` | Server-side JSON schema mode (`responseJsonSchema`) |

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "2.4.0",
+      "version": "2.5.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.0.3",
+  "version": "2.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "2.0.3",
+      "version": "2.4.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@anthropic-ai/sdk": "^0.107.0",
+        "@google/genai": "^1.52.0",
         "@types/node": "^20.0.0",
         "groq-sdk": "^1.3.0",
         "openai": "^6.45.0",
@@ -23,6 +24,7 @@
       },
       "peerDependencies": {
         "@anthropic-ai/sdk": ">=0.20.0",
+        "@google/genai": ">=1.0.0",
         "groq-sdk": ">=0.5.0",
         "node-llama-cpp": ">=3.0.0",
         "ollama": ">=0.5.0",
@@ -31,6 +33,9 @@
       },
       "peerDependenciesMeta": {
         "@anthropic-ai/sdk": {
+          "optional": true
+        },
+        "@google/genai": {
           "optional": true
         },
         "groq-sdk": {
@@ -524,6 +529,31 @@
         "node": ">=18"
       }
     },
+    "node_modules/@google/genai": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/@google/genai/-/genai-1.52.0.tgz",
+      "integrity": "sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "google-auth-library": "^10.3.0",
+        "p-retry": "^4.6.2",
+        "protobufjs": "^7.5.4",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@modelcontextprotocol/sdk": "^1.25.2"
+      },
+      "peerDependenciesMeta": {
+        "@modelcontextprotocol/sdk": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@jest/schemas": {
       "version": "29.6.3",
       "resolved": "https://registry.npmjs.org/@jest/schemas/-/schemas-29.6.3.tgz",
@@ -587,6 +617,72 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.2.tgz",
+      "integrity": "sha512-b1UQwcEZ4yCnMCD8DAL1VlbvBJE9/IX4FTIp7BG1xYpf29SLazLSrqUkj4w7Y5y7cCVP6E5tcqqcI0xemPkHug==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
       "version": "4.62.2",
@@ -969,6 +1065,13 @@
         "undici-types": "~6.21.0"
       }
     },
+    "node_modules/@types/retry": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+      "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@vitest/expect": {
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-1.6.1.tgz",
@@ -1083,6 +1186,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ansi-styles": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
@@ -1124,6 +1237,44 @@
       "engines": {
         "node": "*"
       }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/bundle-require": {
       "version": "5.1.0",
@@ -1241,6 +1392,16 @@
         "node": ">= 8"
       }
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1280,6 +1441,16 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/esbuild": {
@@ -1358,6 +1529,13 @@
         "url": "https://github.com/sindresorhus/execa?sponsor=1"
       }
     },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fast-sha256": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
@@ -1422,6 +1600,30 @@
         }
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
     "node_modules/fix-dts-default-cjs-exports": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fix-dts-default-cjs-exports/-/fix-dts-default-cjs-exports-1.0.1.tgz",
@@ -1432,6 +1634,19 @@
         "magic-string": "^0.30.17",
         "mlly": "^1.7.4",
         "rollup": "^4.34.8"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/fsevents": {
@@ -1447,6 +1662,36 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.2.0.tgz",
+      "integrity": "sha512-CUVb4wcYe+771XevyH6HtGmXFAGGKkIC3kswAP8Z1JCe0j80JMaTPZH930DWFrvo0atjh18Arc0pEyUCWa5bfg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "node-fetch": "^3.3.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/get-func-name": {
@@ -1472,6 +1717,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "10.9.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.9.0.tgz",
+      "integrity": "sha512-xtvUqvINPhTaBm7nXqlYPcrMHJPm1lCNdSovxnKKhTm+4JsvQ+KGVYJViLoH9Yxu8w+T0Qv5HubzYT9BLrppJg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/groq-sdk": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/groq-sdk/-/groq-sdk-1.3.0.tgz",
@@ -1480,6 +1753,20 @@
       "license": "Apache-2.0",
       "bin": {
         "groq-sdk": "bin/cli"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/human-signals": {
@@ -1541,6 +1828,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
     "node_modules/json-schema-to-ts": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
@@ -1553,6 +1850,29 @@
       },
       "engines": {
         "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/lilconfig": {
@@ -1601,6 +1921,13 @@
       "funding": {
         "url": "https://github.com/sponsors/antfu"
       }
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/loupe": {
       "version": "2.3.7",
@@ -1691,6 +2018,46 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/npm-run-path": {
@@ -1793,6 +2160,20 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-retry": {
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+      "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/retry": "0.12.0",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/path-expression-matcher": {
@@ -1966,6 +2347,30 @@
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -1995,6 +2400,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/rollup": {
@@ -2041,6 +2456,27 @@
         "@rollup/rollup-win32-x64-msvc": "4.62.2",
         "fsevents": "~2.3.2"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2976,6 +3412,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -3007,6 +3453,28 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/xml-naming": {

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
   },
   "devDependencies": {
     "@anthropic-ai/sdk": "^0.107.0",
+    "@google/genai": "^1.52.0",
     "@types/node": "^20.0.0",
     "groq-sdk": "^1.3.0",
     "openai": "^6.45.0",
@@ -62,6 +63,7 @@
   },
   "peerDependencies": {
     "@anthropic-ai/sdk": ">=0.20.0",
+    "@google/genai": ">=1.0.0",
     "groq-sdk": ">=0.5.0",
     "node-llama-cpp": ">=3.0.0",
     "ollama": ">=0.5.0",
@@ -70,6 +72,9 @@
   },
   "peerDependenciesMeta": {
     "@anthropic-ai/sdk": {
+      "optional": true
+    },
+    "@google/genai": {
       "optional": true
     },
     "node-llama-cpp": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/backends/deepseek.ts
+++ b/src/backends/deepseek.ts
@@ -1,0 +1,121 @@
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import { buildStructuredPrompt } from "../core/schema.js";
+import { parseAndValidate } from "../core/parse.js";
+import { isXmlInput, isGbnfInput } from "../core/validate.js";
+
+function wantsJsonMode(schema: SchemaInput): boolean {
+  // XML and GBNF output free-form strings, not JSON - DeepSeek requires the literal
+  // word "json" in the prompt when json_object mode is set, same restriction as
+  // Groq, so forcing it for a non-JSON schema would fight the backend, not help it.
+  return !isXmlInput(schema) && !isGbnfInput(schema);
+}
+
+export interface DeepseekBackendOptions {
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+}
+
+/**
+ * DeepSeek - OpenAI-compatible chat completions API, reached via the `openai`
+ * package pointed at DeepSeek's base URL (same dependency `openai()`/`fireworks()`/
+ * `mistral()` already use, no new SDK needed). `guaranteeLevel: "native"` -
+ * `response_format: { type: "json_object" }` is a real, server-side JSON-mode
+ * toggle, same tier as `groq()` - but unlike `fireworks()`/`mistral()`, DeepSeek's
+ * API only supports `"json_object"` (valid JSON), not `"json_schema"` (a specific
+ * schema enforced server-side). No grammar mode - a `{ gbnf }` input is
+ * prompt-only, best-effort, same as every other backend without one.
+ *
+ * Model names: `deepseek-chat`/`deepseek-reasoner` are deprecated 2026-07-24 in
+ * favor of `deepseek-v4-flash` (non-thinking) / `deepseek-v4-pro` (thinking) -
+ * defaults to the former.
+ */
+export function deepseek(options: DeepseekBackendOptions = {}): ShapecraftModel {
+  const modelId = options.model ?? "deepseek-v4-flash";
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("openai").catch(() => {
+      throw new Error("Install openai: npm install openai");
+    });
+    const OpenAI = mod.default ?? mod;
+    const apiKey = options.apiKey ?? process.env.DEEPSEEK_API_KEY;
+    // The openai package falls back to reading OPENAI_API_KEY itself when apiKey
+    // is undefined (not just omitted) — passing it through unchecked would silently
+    // authenticate against DeepSeek's endpoint with an unrelated OpenAI key instead
+    // of failing clearly.
+    if (!apiKey) throw new Error("Missing DeepSeek API key: pass { apiKey } or set DEEPSEEK_API_KEY");
+    return new OpenAI({ apiKey, baseURL: options.baseURL ?? "https://api.deepseek.com" });
+  }
+
+  return {
+    id: `deepseek:${modelId}`,
+    guaranteeLevel: "native",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
+      const deepseekClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const response = await deepseekClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          ...(wantsJsonMode(schema) ? { response_format: { type: "json_object" } } : {}),
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      const raw: string = response.choices[0]?.message?.content ?? "";
+
+      return parseAndValidate<T>(raw, schema, { extractJson: true });
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const deepseekClient = await client();
+
+      const response = await deepseekClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+          ...messages.map((m) => ({ role: m.role, content: m.content })),
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
+    },
+
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
+      const deepseekClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = await deepseekClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          ...(wantsJsonMode(schema) ? { response_format: { type: "json_object" } } : {}),
+          stream: true,
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) yield delta;
+      }
+    },
+  };
+}

--- a/src/backends/fireworks.ts
+++ b/src/backends/fireworks.ts
@@ -1,0 +1,125 @@
+import { z } from "zod";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { isZodSchema, isGbnfInput } from "../core/validate.js";
+import { parseAndValidate } from "../core/parse.js";
+
+export interface FireworksBackendOptions {
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function responseFormatFor(schema: SchemaInput): any {
+  // Fireworks' grammar mode applies a GBNF grammar as a genuine token-level
+  // constraint (not the prompt-only best-effort path other cloud backends fall
+  // back to for gbnf) - see https://docs.fireworks.ai/structured-responses/structured-output-grammar-based
+  if (isGbnfInput(schema)) return { type: "grammar", grammar: schema.gbnf };
+  return isZodSchema(schema)
+    ? {
+        type: "json_schema" as const,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        json_schema: { name: "output", schema: toJsonSchema(schema as z.ZodType<any>) },
+      }
+    : "jsonSchema" in (schema as object)
+      ? {
+          type: "json_schema" as const,
+          json_schema: { name: "output", schema: (schema as { jsonSchema: Record<string, unknown> }).jsonSchema },
+        }
+      : { type: "json_object" as const };
+}
+
+/**
+ * Fireworks AI - OpenAI-compatible chat completions API, reached via the `openai`
+ * package pointed at Fireworks' base URL (same dependency `openai()` already uses,
+ * no new SDK needed). The differentiator over `openai()`/`groq()` is grammar mode:
+ * a `{ gbnf }` input gets `response_format: { type: "grammar", grammar }`, a real
+ * token-level constraint, not a prompted-and-checked best-effort string.
+ */
+export function fireworks(options: FireworksBackendOptions = {}): ShapecraftModel {
+  const modelId = options.model ?? "accounts/fireworks/models/llama-v3p1-70b-instruct";
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("openai").catch(() => {
+      throw new Error("Install openai: npm install openai");
+    });
+    const OpenAI = mod.default ?? mod;
+    return new OpenAI({
+      apiKey: options.apiKey ?? process.env.FIREWORKS_API_KEY,
+      baseURL: options.baseURL ?? "https://api.fireworks.ai/inference/v1",
+    });
+  }
+
+  return {
+    id: `fireworks:${modelId}`,
+    guaranteeLevel: "native",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
+      const fireworksClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const response = await fireworksClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      const raw: string = response.choices[0]?.message?.content ?? "";
+
+      return parseAndValidate<T>(raw, schema);
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const fireworksClient = await client();
+
+      const response = await fireworksClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+          ...messages.map((m) => ({ role: m.role, content: m.content })),
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
+    },
+
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
+      const fireworksClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = await fireworksClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+          stream: true,
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) yield delta;
+      }
+    },
+  };
+}

--- a/src/backends/gemini.ts
+++ b/src/backends/gemini.ts
@@ -1,0 +1,135 @@
+import { z } from "zod";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { isZodSchema, isGbnfInput } from "../core/validate.js";
+import { parseAndValidate } from "../core/parse.js";
+
+export interface GeminiBackendOptions {
+  model?: string;
+  apiKey?: string;
+}
+
+interface ResponseConfig {
+  responseMimeType?: "application/json";
+  responseJsonSchema?: unknown;
+}
+
+function responseConfigFor(schema: SchemaInput): ResponseConfig {
+  // Gemini has no grammar mode (unlike fireworks()/llamaCpp()) - a gbnf input is
+  // prompt-only, best-effort, same as every other backend without one.
+  if (isGbnfInput(schema)) return {};
+
+  if (isZodSchema(schema)) {
+    // responseJsonSchema accepts standard JSON Schema (zodToJsonSchema output)
+    // directly - unlike the older responseSchema field, which needs Gemini's own
+    // Type-enum-based OpenAPI-subset shape instead of plain JSON Schema.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return { responseMimeType: "application/json", responseJsonSchema: toJsonSchema(schema as z.ZodType<any>) };
+  }
+
+  if ("jsonSchema" in (schema as object)) {
+    return {
+      responseMimeType: "application/json",
+      responseJsonSchema: (schema as { jsonSchema: Record<string, unknown> }).jsonSchema,
+    };
+  }
+
+  return { responseMimeType: "application/json" };
+}
+
+/**
+ * Google Gemini via the official `@google/genai` SDK - not the OpenAI-compatible
+ * endpoint, since that's a migration bridge for OpenAI users rather than Gemini's
+ * primary integration path, and doesn't expose `responseJsonSchema` (plain JSON
+ * Schema) vs. the older `responseSchema` (Gemini's own Type-enum OpenAPI subset).
+ * `guaranteeLevel: "native"` - `responseJsonSchema`/`responseMimeType` is server-side
+ * constrained decoding, the same tier as `openai()`/`groq()`/`fireworks()`/`mistral()`.
+ */
+export function gemini(options: GeminiBackendOptions = {}): ShapecraftModel {
+  // "gemini-2.5-flash" 404s for new-user accounts ("no longer available to new
+  // users") despite still being listed by models.list() - confirmed live. The
+  // "-latest" alias tracks whatever Google currently recommends instead of a
+  // version string that can get deprecated out from under a hardcoded default.
+  const modelId = options.model ?? "gemini-flash-latest";
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("@google/genai").catch(() => {
+      throw new Error("Install @google/genai: npm install @google/genai");
+    });
+    const { GoogleGenAI } = mod;
+    return new GoogleGenAI({ apiKey: options.apiKey ?? process.env.GEMINI_API_KEY });
+  }
+
+  return {
+    id: `gemini:${modelId}`,
+    guaranteeLevel: "native",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
+      const ai = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const response = await ai.models.generateContent({
+        model: modelId,
+        contents: user,
+        config: {
+          systemInstruction: system,
+          ...responseConfigFor(schema),
+          ...(callOptions?.signal ? { abortSignal: callOptions.signal } : {}),
+        },
+      });
+
+      const raw: string = response.text ?? "";
+
+      // extractJson is a defensive no-op if Gemini never wraps output in a markdown
+      // fence - kept for the same reason mistral()/openRouter() keep it: cheap
+      // insurance against a provider-side formatting quirk breaking every call.
+      return parseAndValidate<T>(raw, schema, { extractJson: true });
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const ai = await client();
+
+      const contents = messages.map((m) => ({
+        role: m.role === "assistant" ? "model" : "user",
+        parts: [{ text: m.content }],
+      }));
+
+      const response = await ai.models.generateContent({
+        model: modelId,
+        contents,
+        config: systemPrompt ? { systemInstruction: systemPrompt } : undefined,
+      });
+
+      return response.text ?? "";
+    },
+
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
+      const ai = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = await ai.models.generateContentStream({
+        model: modelId,
+        contents: user,
+        config: {
+          systemInstruction: system,
+          ...responseConfigFor(schema),
+          ...(callOptions?.signal ? { abortSignal: callOptions.signal } : {}),
+        },
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.text;
+        if (delta) yield delta;
+      }
+    },
+  };
+}

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -6,3 +6,4 @@ export { llamaCpp } from "./llamaCpp.js";
 export { fireworks } from "./fireworks.js";
 export { mistral } from "./mistral.js";
 export { openRouter } from "./openRouter.js";
+export { gemini } from "./gemini.js";

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -5,3 +5,4 @@ export { groq } from "./groq.js";
 export { llamaCpp } from "./llamaCpp.js";
 export { fireworks } from "./fireworks.js";
 export { mistral } from "./mistral.js";
+export { openRouter } from "./openRouter.js";

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -4,3 +4,4 @@ export { anthropic } from "./anthropic.js";
 export { groq } from "./groq.js";
 export { llamaCpp } from "./llamaCpp.js";
 export { fireworks } from "./fireworks.js";
+export { mistral } from "./mistral.js";

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -3,3 +3,4 @@ export { ollama } from "./ollama.js";
 export { anthropic } from "./anthropic.js";
 export { groq } from "./groq.js";
 export { llamaCpp } from "./llamaCpp.js";
+export { fireworks } from "./fireworks.js";

--- a/src/backends/index.ts
+++ b/src/backends/index.ts
@@ -7,3 +7,4 @@ export { fireworks } from "./fireworks.js";
 export { mistral } from "./mistral.js";
 export { openRouter } from "./openRouter.js";
 export { gemini } from "./gemini.js";
+export { deepseek } from "./deepseek.js";

--- a/src/backends/mistral.ts
+++ b/src/backends/mistral.ts
@@ -1,0 +1,128 @@
+import { z } from "zod";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { isZodSchema, isGbnfInput } from "../core/validate.js";
+import { parseAndValidate } from "../core/parse.js";
+
+export interface MistralBackendOptions {
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function responseFormatFor(schema: SchemaInput): any {
+  // Mistral has no grammar mode (unlike fireworks()) - a gbnf input is prompt-only,
+  // best-effort, same as openai()/groq(). Forcing json_schema mode here would fight
+  // the grammar's free-form string output.
+  if (isGbnfInput(schema)) return undefined;
+  return isZodSchema(schema)
+    ? {
+        type: "json_schema" as const,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        json_schema: { name: "output", strict: true, schema: toJsonSchema(schema as z.ZodType<any>) },
+      }
+    : "jsonSchema" in (schema as object)
+      ? {
+          type: "json_schema" as const,
+          json_schema: { name: "output", strict: false, schema: (schema as { jsonSchema: Record<string, unknown> }).jsonSchema },
+        }
+      : { type: "json_object" as const };
+}
+
+/**
+ * Mistral AI - OpenAI-compatible chat completions API, reached via the `openai`
+ * package pointed at Mistral's base URL (same dependency `openai()`/`fireworks()`
+ * already use, no new SDK needed). `guaranteeLevel: "native"` - `response_format:
+ * { type: "json_schema", ... }` is a server-side enforced schema, same tier as
+ * `openai()`/`groq()`/`fireworks()`.
+ */
+export function mistral(options: MistralBackendOptions = {}): ShapecraftModel {
+  const modelId = options.model ?? "mistral-large-latest";
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("openai").catch(() => {
+      throw new Error("Install openai: npm install openai");
+    });
+    const OpenAI = mod.default ?? mod;
+    return new OpenAI({
+      apiKey: options.apiKey ?? process.env.MISTRAL_API_KEY,
+      baseURL: options.baseURL ?? "https://api.mistral.ai/v1",
+    });
+  }
+
+  return {
+    id: `mistral:${modelId}`,
+    guaranteeLevel: "native",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
+      const mistralClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const response = await mistralClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      const raw: string = response.choices[0]?.message?.content ?? "";
+
+      // Mistral sometimes wraps `json_schema`-mode output in a ```json fence despite
+      // response_format supposedly enforcing raw JSON - extractJson is a safe no-op
+      // when it doesn't (same pattern anthropic() uses for the same reason).
+      return parseAndValidate<T>(raw, schema, { extractJson: true });
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const mistralClient = await client();
+
+      const response = await mistralClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+          ...messages.map((m) => ({ role: m.role, content: m.content })),
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
+    },
+
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
+      const mistralClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = await mistralClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+          stream: true,
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) yield delta;
+      }
+    },
+  };
+}

--- a/src/backends/openRouter.ts
+++ b/src/backends/openRouter.ts
@@ -1,0 +1,130 @@
+import { z } from "zod";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
+import { isZodSchema, isGbnfInput } from "../core/validate.js";
+import { parseAndValidate } from "../core/parse.js";
+
+export interface OpenRouterBackendOptions {
+  model?: string;
+  apiKey?: string;
+  baseURL?: string;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function responseFormatFor(schema: SchemaInput): any {
+  // No grammar mode - OpenRouter is pass-through across many different underlying
+  // providers, so there's no single grammar API to target. A gbnf input is
+  // prompt-only, best-effort, same as openai()/groq()/mistral().
+  if (isGbnfInput(schema)) return undefined;
+  return isZodSchema(schema)
+    ? {
+        type: "json_schema" as const,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        json_schema: { name: "output", strict: true, schema: toJsonSchema(schema as z.ZodType<any>) },
+      }
+    : "jsonSchema" in (schema as object)
+      ? {
+          type: "json_schema" as const,
+          json_schema: { name: "output", strict: false, schema: (schema as { jsonSchema: Record<string, unknown> }).jsonSchema },
+        }
+      : { type: "json_object" as const };
+}
+
+/**
+ * OpenRouter - OpenAI-compatible chat completions API, reached via the `openai`
+ * package pointed at OpenRouter's base URL (same dependency `openai()`/`fireworks()`/
+ * `mistral()` already use, no new SDK needed). `guaranteeLevel: "best-effort"`,
+ * deliberately not `"native"` like the other cloud backends - OpenRouter is
+ * pass-through across many different underlying providers/models, and
+ * `response_format: { type: "json_schema" }` enforcement isn't guaranteed for every
+ * model it can route to, only the ones that actually support it themselves. Defensively
+ * requests `extractJson: true` on every call for the same reason `anthropic()` needs
+ * it - an arbitrary underlying model may wrap output in a markdown fence regardless of
+ * what `response_format` asked for.
+ */
+export function openRouter(options: OpenRouterBackendOptions = {}): ShapecraftModel {
+  const modelId = options.model ?? "openai/gpt-4o-mini";
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  async function client(): Promise<any> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mod: any = await import("openai").catch(() => {
+      throw new Error("Install openai: npm install openai");
+    });
+    const OpenAI = mod.default ?? mod;
+    return new OpenAI({
+      apiKey: options.apiKey ?? process.env.OPENROUTER_API_KEY,
+      baseURL: options.baseURL ?? "https://openrouter.ai/api/v1",
+    });
+  }
+
+  return {
+    id: `openrouter:${modelId}`,
+    guaranteeLevel: "best-effort",
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+
+    async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
+      const openRouterClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const response = await openRouterClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      const raw: string = response.choices[0]?.message?.content ?? "";
+
+      return parseAndValidate<T>(raw, schema, { extractJson: true });
+    },
+
+    async chat(messages: ChatMessage[], systemPrompt?: string): Promise<string> {
+      const openRouterClient = await client();
+
+      const response = await openRouterClient.chat.completions.create({
+        model: modelId,
+        messages: [
+          ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+          ...messages.map((m) => ({ role: m.role, content: m.content })),
+        ],
+      });
+
+      return response.choices[0]?.message?.content ?? "";
+    },
+
+    async *generateStream<T>(
+      prompt: string,
+      schema: SchemaInput<T>,
+      systemPrompt?: string,
+      callOptions?: ModelCallOptions
+    ): AsyncIterable<string> {
+      const openRouterClient = await client();
+      const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
+
+      const stream = await openRouterClient.chat.completions.create(
+        {
+          model: modelId,
+          messages: [
+            { role: "system", content: system },
+            { role: "user", content: user },
+          ],
+          response_format: responseFormatFor(schema),
+          stream: true,
+        },
+        callOptions?.signal ? { signal: callOptions.signal } : undefined
+      );
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      for await (const chunk of stream as AsyncIterable<any>) {
+        const delta = chunk.choices?.[0]?.delta?.content;
+        if (delta) yield delta;
+      }
+    },
+  };
+}

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -7,8 +7,16 @@ import { isXmlInput, isGbnfInput, isZodSchema } from "./validate.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toJsonSchema(schema: z.ZodType<any>): Record<string, unknown> {
+  // jsonSchema7 (the default target), not openApi3 - openApi3 emits the old OpenAPI
+  // 3.0 boolean form for exclusive bounds (`.positive()`/`.negative()`/`.gt()`/`.lt()`)
+  // - exclusiveMinimum: true + a separate minimum - instead of the numeric form real
+  // JSON Schema requires (exclusiveMinimum: 0). Backends that validate the schema
+  // itself strictly (confirmed on Mistral, likely Fireworks too) reject the boolean
+  // form outright with a 422 before the model ever runs.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return zodToJsonSchema(schema as any, { target: "openApi3" }) as Record<string, unknown>;
+  const result = zodToJsonSchema(schema as any, { target: "jsonSchema7" }) as Record<string, unknown>;
+  delete result.$schema;
+  return result;
 }
 
 export function buildStructuredPrompt(

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -7,6 +7,7 @@ import { anthropic } from "../src/backends/anthropic.js";
 import { ollama } from "../src/backends/ollama.js";
 import { fireworks } from "../src/backends/fireworks.js";
 import { mistral } from "../src/backends/mistral.js";
+import { openRouter } from "../src/backends/openRouter.js";
 import { mockModel } from "./helpers/index.js";
 
 const PersonSchema = z.object({ name: z.string(), age: z.number() });
@@ -19,6 +20,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["ollama", ollama({ model: "llama3.2" })],
     ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
     ["mistral", mistral({ model: "mistral-large-latest" })],
+    ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
   ])("%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false", (_name, model) => {
     expect(model.capabilities).toEqual({
       streaming: true,
@@ -36,9 +38,14 @@ describe("ShapecraftModel.capabilities", () => {
     ["ollama", ollama({ model: "llama3.2" })],
     ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
     ["mistral", mistral({ model: "mistral-large-latest" })],
+    ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
   ])("%s's declared capabilities match its actual duck-typed method presence", (_name, model) => {
     expect(model.capabilities?.streaming).toBe(typeof model.generateStream === "function");
     expect(model.capabilities?.chat).toBe(typeof model.chat === "function");
+  });
+
+  it("openRouter() reports best-effort, not native - pass-through across many underlying models means json_schema enforcement isn't guaranteed for all of them", () => {
+    expect(openRouter({ model: "openai/gpt-4o-mini" }).guaranteeLevel).toBe("best-effort");
   });
 
   it("is optional — a pre-existing custom ShapecraftModel without capabilities still satisfies the interface and works", async () => {

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -5,6 +5,7 @@ import { openai } from "../src/backends/openai.js";
 import { groq } from "../src/backends/groq.js";
 import { anthropic } from "../src/backends/anthropic.js";
 import { ollama } from "../src/backends/ollama.js";
+import { fireworks } from "../src/backends/fireworks.js";
 import { mockModel } from "./helpers/index.js";
 
 const PersonSchema = z.object({ name: z.string(), age: z.number() });
@@ -15,6 +16,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["groq", groq({ model: "llama-3.3-70b-versatile" })],
     ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
     ["ollama", ollama({ model: "llama3.2" })],
+    ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
   ])("%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false", (_name, model) => {
     expect(model.capabilities).toEqual({
       streaming: true,
@@ -30,6 +32,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["groq", groq({ model: "llama-3.3-70b-versatile" })],
     ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
     ["ollama", ollama({ model: "llama3.2" })],
+    ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
   ])("%s's declared capabilities match its actual duck-typed method presence", (_name, model) => {
     expect(model.capabilities?.streaming).toBe(typeof model.generateStream === "function");
     expect(model.capabilities?.chat).toBe(typeof model.chat === "function");

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { z } from "zod";
 import { generate } from "../src/core/generate.js";
 import { openai } from "../src/backends/openai.js";
@@ -9,6 +9,7 @@ import { fireworks } from "../src/backends/fireworks.js";
 import { mistral } from "../src/backends/mistral.js";
 import { openRouter } from "../src/backends/openRouter.js";
 import { gemini } from "../src/backends/gemini.js";
+import { deepseek } from "../src/backends/deepseek.js";
 import { mockModel } from "./helpers/index.js";
 
 const PersonSchema = z.object({ name: z.string(), age: z.number() });
@@ -23,6 +24,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["mistral", mistral({ model: "mistral-large-latest" })],
     ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
     ["gemini", gemini({ model: "gemini-flash-latest" })],
+    ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
   ])("%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false", (_name, model) => {
     expect(model.capabilities).toEqual({
       streaming: true,
@@ -42,6 +44,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["mistral", mistral({ model: "mistral-large-latest" })],
     ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
     ["gemini", gemini({ model: "gemini-flash-latest" })],
+    ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
   ])("%s's declared capabilities match its actual duck-typed method presence", (_name, model) => {
     expect(model.capabilities?.streaming).toBe(typeof model.generateStream === "function");
     expect(model.capabilities?.chat).toBe(typeof model.chat === "function");
@@ -53,6 +56,27 @@ describe("ShapecraftModel.capabilities", () => {
 
   it("gemini() reports native - responseSchema/responseJsonSchema is server-side constrained decoding, same tier as openai()/groq()", () => {
     expect(gemini({ model: "gemini-flash-latest" }).guaranteeLevel).toBe("native");
+  });
+
+  it("deepseek() reports native - response_format: json_object is a real server-side JSON-mode toggle, same tier as groq() - but DeepSeek has no json_schema mode, unlike fireworks()/mistral()", () => {
+    expect(deepseek({ model: "deepseek-v4-flash" }).guaranteeLevel).toBe("native");
+  });
+
+  describe("deepseek() missing-key guard", () => {
+    afterEach(() => vi.unstubAllEnvs());
+
+    // Regression guard: the openai package falls back to reading OPENAI_API_KEY
+    // itself when apiKey is undefined (not just omitted) - without this guard,
+    // an unconfigured deepseek() would silently authenticate against DeepSeek's
+    // endpoint using an unrelated OpenAI key instead of failing clearly.
+    it("throws a clear error instead of silently falling back to OPENAI_API_KEY", async () => {
+      vi.stubEnv("DEEPSEEK_API_KEY", "");
+      vi.stubEnv("OPENAI_API_KEY", "sk-unrelated-openai-key");
+
+      await expect(generate(deepseek({ model: "deepseek-v4-flash" }), PersonSchema, "extract data")).rejects.toThrow(
+        /Missing DeepSeek API key/
+      );
+    });
   });
 
   it("is optional — a pre-existing custom ShapecraftModel without capabilities still satisfies the interface and works", async () => {

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -6,6 +6,7 @@ import { groq } from "../src/backends/groq.js";
 import { anthropic } from "../src/backends/anthropic.js";
 import { ollama } from "../src/backends/ollama.js";
 import { fireworks } from "../src/backends/fireworks.js";
+import { mistral } from "../src/backends/mistral.js";
 import { mockModel } from "./helpers/index.js";
 
 const PersonSchema = z.object({ name: z.string(), age: z.number() });
@@ -17,6 +18,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
     ["ollama", ollama({ model: "llama3.2" })],
     ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
+    ["mistral", mistral({ model: "mistral-large-latest" })],
   ])("%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false", (_name, model) => {
     expect(model.capabilities).toEqual({
       streaming: true,
@@ -33,6 +35,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
     ["ollama", ollama({ model: "llama3.2" })],
     ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
+    ["mistral", mistral({ model: "mistral-large-latest" })],
   ])("%s's declared capabilities match its actual duck-typed method presence", (_name, model) => {
     expect(model.capabilities?.streaming).toBe(typeof model.generateStream === "function");
     expect(model.capabilities?.chat).toBe(typeof model.chat === "function");
@@ -45,4 +48,23 @@ describe("ShapecraftModel.capabilities", () => {
     const result = await generate(legacy, PersonSchema, "get person");
     expect(result.data).toEqual({ name: "Alice", age: 30 });
   });
+});
+
+const hasMistral = !!process.env.MISTRAL_API_KEY;
+
+// Regression guard: caught live while dogfood-testing mistral() - despite
+// response_format: { type: "json_schema" } supposedly enforcing raw JSON,
+// mistral-large-latest sometimes wraps the output in a ```json fence anyway.
+// Without extractJson: true in mistral.ts's generate(), that fails JSON.parse
+// outright and burns all 3 retries before MaxRetriesExceededError.
+describe("Mistral backend (real API)", () => {
+  it.skipIf(!hasMistral)("survives a markdown-fence-wrapped json_schema response", async () => {
+    const model = mistral({ model: "mistral-large-latest" });
+    const result = await generate(
+      model,
+      z.object({ name: z.string(), age: z.number(), email: z.string() }),
+      "Jane Doe is 34 years old, email jane.doe@example.com"
+    );
+    expect(result.data).toEqual({ name: "Jane Doe", age: 34, email: "jane.doe@example.com" });
+  }, 30_000);
 });

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -8,6 +8,7 @@ import { ollama } from "../src/backends/ollama.js";
 import { fireworks } from "../src/backends/fireworks.js";
 import { mistral } from "../src/backends/mistral.js";
 import { openRouter } from "../src/backends/openRouter.js";
+import { gemini } from "../src/backends/gemini.js";
 import { mockModel } from "./helpers/index.js";
 
 const PersonSchema = z.object({ name: z.string(), age: z.number() });
@@ -21,6 +22,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
     ["mistral", mistral({ model: "mistral-large-latest" })],
     ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
+    ["gemini", gemini({ model: "gemini-flash-latest" })],
   ])("%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false", (_name, model) => {
     expect(model.capabilities).toEqual({
       streaming: true,
@@ -39,6 +41,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
     ["mistral", mistral({ model: "mistral-large-latest" })],
     ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
+    ["gemini", gemini({ model: "gemini-flash-latest" })],
   ])("%s's declared capabilities match its actual duck-typed method presence", (_name, model) => {
     expect(model.capabilities?.streaming).toBe(typeof model.generateStream === "function");
     expect(model.capabilities?.chat).toBe(typeof model.chat === "function");
@@ -46,6 +49,10 @@ describe("ShapecraftModel.capabilities", () => {
 
   it("openRouter() reports best-effort, not native - pass-through across many underlying models means json_schema enforcement isn't guaranteed for all of them", () => {
     expect(openRouter({ model: "openai/gpt-4o-mini" }).guaranteeLevel).toBe("best-effort");
+  });
+
+  it("gemini() reports native - responseSchema/responseJsonSchema is server-side constrained decoding, same tier as openai()/groq()", () => {
+    expect(gemini({ model: "gemini-flash-latest" }).guaranteeLevel).toBe("native");
   });
 
   it("is optional — a pre-existing custom ShapecraftModel without capabilities still satisfies the interface and works", async () => {

--- a/tests/gbnf.test.ts
+++ b/tests/gbnf.test.ts
@@ -3,11 +3,13 @@ import { generate } from "../src/core/generate.js";
 import { generateStream } from "../src/core/stream.js";
 import { matchesGbnf, parseGbnf, buildGbnfSystemPrompt } from "../src/core/gbnf.js";
 import { groq } from "../src/backends/groq.js";
+import { fireworks } from "../src/backends/fireworks.js";
 import { MaxRetriesExceededError } from "../src/types.js";
 import type { ShapecraftModel, StreamEvent } from "../src/types.js";
 import { mockModel } from "./helpers/index.js";
 
 const hasGroq = !!process.env.GROQ_API_KEY;
+const hasFireworks = !!process.env.FIREWORKS_API_KEY;
 
 async function collect<T>(iter: AsyncIterable<T>): Promise<T[]> {
   const out: T[] = [];
@@ -308,6 +310,31 @@ describe("GBNF input — Groq backend (real API)", () => {
 
   it.skipIf(!hasGroq)("streaming does not force json_object mode either", async () => {
     const model = groq({ model: "llama-3.3-70b-versatile" });
+    const stream = generateStream(model, { gbnf: `root ::= "positive" | "negative" | "neutral"` }, "Classify: 'I love it!'");
+    const result = await stream.result;
+    expect(["positive", "negative", "neutral"]).toContain(result.data);
+  }, 30_000);
+});
+
+// ─── Real backend: Fireworks AI (skip-gated) ──────────────────────────────────
+// Fireworks' grammar mode (response_format: { type: "grammar", grammar }) is a
+// genuine token-level constraint, not a prompted-and-checked best-effort string
+// like every other cloud backend's gbnf path - this is the actual reason a
+// dedicated fireworks() backend exists instead of pointing openai() at
+// Fireworks' base URL. https://docs.fireworks.ai/structured-responses/structured-output-grammar-based
+describe("GBNF input — Fireworks backend (real API)", () => {
+  it.skipIf(!hasFireworks)("produces grammar-conforming output via native grammar mode", async () => {
+    const model = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" });
+    const result = await generate(
+      model,
+      { gbnf: `root ::= "positive" | "negative" | "neutral"` },
+      "Classify the sentiment: 'This is the best purchase I've made all year!'"
+    );
+    expect(["positive", "negative", "neutral"]).toContain(result.data);
+  }, 30_000);
+
+  it.skipIf(!hasFireworks)("streaming works the same way through grammar mode", async () => {
+    const model = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" });
     const stream = generateStream(model, { gbnf: `root ::= "positive" | "negative" | "neutral"` }, "Classify: 'I love it!'");
     const result = await stream.result;
     expect(["positive", "negative", "neutral"]).toContain(result.data);


### PR DESCRIPTION
Five new backends, plus a real bug fix found while building them that affects every existing backend's Zod-schema handling.

- fireworks() - guaranteeLevel: "native". The differentiator: { gbnf } input gets Fireworks' own server-side grammar mode (response_format: { type: "grammar", grammar }) - a genuine token-level constraint, the same real guarantee llamaCpp() gives locally, without needing a local .gguf file. Every other cloud backend just prompts-and-checks for gbnf.
- mistral() - guaranteeLevel: "native", server-side json_schema enforcement, same tier as openai()/groq()/fireworks().
- openRouter() - guaranteeLevel: "best-effort" deliberately, not "native" - it's pass-through across many underlying providers/models, and json_schema enforcement isn't guaranteed for every model it can route to.
- gemini() - via the official @google/genai SDK (not openai-pointed-at-a-base-URL like the others) - Gemini's OpenAI-compat layer doesn't expose responseJsonSchema. guaranteeLevel: "native".
- deepseek() - guaranteeLevel: "native" via json_object mode, but no schema-strict mode (unlike fireworks/mistral), same tier as groq(). Defaults to deepseek-v4-flash.

All five reuse the openai package pointed at a different baseURL except gemini() - no new dependency for four of them.

Fixed: toJsonSchema() emitted the legacy OpenAPI 3.0 boolean form for exclusive bounds (exclusiveMinimum: true + separate minimum) instead of the numeric form real JSON Schema requires. Backends that validate schemas strictly (confirmed on Mistral - rejected with a 422) reject the boolean form outright. Switched target from openApi3 to jsonSchema7. Affects every backend's Zod-schema handling, verified live against groq(), anthropic(), and ollama().

```
import { generate, fireworks, mistral, gemini, deepseek, openRouter } from "@aviasole/shapecraft";

const model = fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" });
const result = await generate(model, schema, "Extract: Jane Doe, 28");
```
