### PR TITLE
feat: add native tool/function-calling support (generateWithTools)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,13 +19,30 @@
   - `ToolDefinition.parameters` accepts Zod or `{ jsonSchema }` only. `pattern`/`validate`/
     `xml` have no sensible named-parameters representation and throw clearly instead of
     silently producing a broken tool definition.
-  - Available on 8 of 9 backends: `openai()`, `groq()`, `fireworks()`, `mistral()`,
-    `openRouter()` and `deepseek()` share one `openAiCompatibleToolCall()` implementation
-    (identical wire format); `anthropic()` and `ollama()` have their own. `gemini()` is
-    the exception - it goes through `@google/genai` rather than an OpenAI-shaped
-    chat/completions endpoint. `ModelCapabilities.toolCalling` reports this per backend.
-  - Live-verified against Groq, Anthropic and Mistral. The other OpenAI-compatible
-    backends take the identical code path but had no usable credentials to test against.
+  - Available on every backend except `llamaCpp()` (local GGUF inference exposes no
+    tools API). `openai()`, `groq()`, `fireworks()`, `mistral()`, `openRouter()` and
+    `deepseek()` share one `openAiCompatibleToolCall()` implementation (identical wire
+    format); `anthropic()`, `ollama()` and `gemini()` each have their own.
+    `ModelCapabilities.toolCalling` reports this per backend - check the flag rather
+    than hardcoding the list.
+  - `gemini()` needs its own path: `@google/genai` models a tool turn as
+    `functionCall`/`functionResponse` Parts inside `contents` rather than OpenAI's flat
+    `tool_calls` array, uses `parametersJsonSchema` (plain JSON Schema) over the older
+    Type-enum `parameters`, and rejects a replayed `functionCall` Part that has lost its
+    opaque `thoughtSignature`. That token has no home on the shared `ToolCall` type, so
+    the backend keeps it per model instance and reattaches it on the next turn.
+  - Live-verified against Groq, Anthropic, Mistral and Gemini. `fireworks()`,
+    `openRouter()` and `deepseek()` take the identical OpenAI-compatible code path but
+    had no usable credentials to test against.
+
+### Fixed
+
+- **`llamaCpp()` declared no `capabilities` object at all** - the only backend that
+  didn't, so `model.capabilities` was `undefined` there while every other backend
+  returned one. It now reports `streaming: false`/`toolCalling: false` explicitly
+  (no token-delta iterator, no tools API) rather than saying nothing.
+- `ModelCapabilities.toolCalling`'s doc comment still read "Not yet built by any
+  backend", which shipped to consumers in the generated `.d.ts`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,39 @@
 # Changelog
 
+## [2.8.0] - 2026-07-31
+
+### Added
+
+- **Native tool/function-calling** - `generateWithTools(model, tools, schema, prompt, options?)`.
+  Passes the running message history plus your tool definitions to the model's own
+  `toolCall()` turn, executes requested tools locally (validating each call's arguments
+  against that tool's `parameters` schema first), feeds results back, and repeats until
+  the model stops asking for tools. The final answer is extracted through an ordinary
+  `generate()` call over the transcript, so the structured-output guarantee is identical
+  to any standalone `generate()` - not a weaker tool-calling-specific check.
+  - A bad tool call (unknown name, or arguments that fail the tool's schema) is fed back
+    to the model as a `tool` error message so it can retry - re-prompting can fix that.
+    A handler that throws is not recoverable that way, so it aborts immediately with
+    `ToolExecutionError`. Exceeding `maxTurns` (default 10) throws
+    `MaxToolTurnsExceededError`.
+  - `ToolDefinition.parameters` accepts Zod or `{ jsonSchema }` only. `pattern`/`validate`/
+    `xml` have no sensible named-parameters representation and throw clearly instead of
+    silently producing a broken tool definition.
+  - Available on 8 of 9 backends: `openai()`, `groq()`, `fireworks()`, `mistral()`,
+    `openRouter()` and `deepseek()` share one `openAiCompatibleToolCall()` implementation
+    (identical wire format); `anthropic()` and `ollama()` have their own. `gemini()` is
+    the exception - it goes through `@google/genai` rather than an OpenAI-shaped
+    chat/completions endpoint. `ModelCapabilities.toolCalling` reports this per backend.
+  - Live-verified against Groq, Anthropic and Mistral. The other OpenAI-compatible
+    backends take the identical code path but had no usable credentials to test against.
+
+### Fixed
+
+- `toJsonSchema()` now strips `$schema` on the Zod v4 path too, not just the
+  `zod-to-json-schema` fallback. Zod v4's native `toJSONSchema()` emits its own
+  draft-2020-12 `$schema` key, which would otherwise reach backends that reject
+  extraneous top-level schema keys.
+
 ## [2.7.0] - 2026-07-31
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -765,7 +765,7 @@ Out of scope for v1: concurrent/parallel agents (use `generateBatch()` for indep
 
 ## Tool Calling
 
-Lets a model call your own functions mid-turn, see the results, and continue - using each provider's **native** tool-calling API (OpenAI/Groq/Anthropic/Ollama each have a different wire shape under the hood, normalized to one interface), not a prompted convention. This is a different mechanism from `runAgents()`/skill-style dispatch - it's the one capability every backend previously declared `false` for.
+Lets a model call your own functions mid-turn, see the results, and continue - using each provider's **native** tool-calling API, not a prompted convention. The OpenAI-wire-format backends share one implementation; Anthropic and Ollama each have a different wire shape under the hood, normalized to the same interface. This is a different mechanism from `runAgents()`/skill-style dispatch.
 
 ```typescript
 import { generateWithTools, anthropic } from "@aviasole/shapecraft";
@@ -800,7 +800,7 @@ What this does and doesn't guarantee:
 - **A tool handler's own correctness is entirely your responsibility.** shapecraft only guarantees the handler's *return value* gets fed back to the model as-is.
 - **No loop-prevention beyond `maxTurns`** (default 10) - a model that keeps requesting tools forever throws `MaxToolTurnsExceededError`. A handler that throws aborts immediately with `ToolExecutionError` instead (a business-logic failure, never retried the way a bad argument is - re-prompting the model can't fix a broken handler).
 
-Available today on `openai()`, `groq()`, `anthropic()`, `ollama()`. Not yet on `fireworks()`/`mistral()`/`openRouter()`/`gemini()`/`deepseek()`/`llamaCpp()` (different branches - natural follow-up once merged). Non-streaming in v1, same reasoning `runAgents()` gives for skipping streaming.
+Available on `openai()`, `groq()`, `anthropic()`, `ollama()`, `fireworks()`, `mistral()`, `openRouter()` and `deepseek()`. Not on `gemini()` (routed through `@google/genai`, not an OpenAI-shaped chat/completions endpoint) or `llamaCpp()` (local GGUF inference, no tools API). Check `model.capabilities.toolCalling` rather than hardcoding that list. Non-streaming in v1, same reasoning `runAgents()` gives for skipping streaming.
 
 ## What shapecraft guarantees — and what it doesn't
 

--- a/README.md
+++ b/README.md
@@ -763,6 +763,45 @@ What this does and doesn't guarantee:
 
 Out of scope for v1: concurrent/parallel agents (use `generateBatch()` for independent work), autonomous routing, tool-calling within a step, shared mutable state across agents, and persisted/resumable chains.
 
+## Tool Calling
+
+Lets a model call your own functions mid-turn, see the results, and continue - using each provider's **native** tool-calling API (OpenAI/Groq/Anthropic/Ollama each have a different wire shape under the hood, normalized to one interface), not a prompted convention. This is a different mechanism from `runAgents()`/skill-style dispatch - it's the one capability every backend previously declared `false` for.
+
+```typescript
+import { generateWithTools, anthropic } from "@aviasole/shapecraft";
+import { z } from "zod";
+import type { ToolDefinition } from "@aviasole/shapecraft";
+
+const getWeather: ToolDefinition = {
+  name: "get_weather",
+  description: "Get current weather for a city",
+  parameters: z.object({ city: z.string() }),
+  handler: async ({ city }: { city: string }) => ({ city, tempC: 18, condition: "cloudy" }),
+};
+
+const result = await generateWithTools(
+  anthropic({ model: "claude-haiku-4-5-20251001" }),
+  [getWeather],
+  z.object({ summary: z.string() }),
+  "What's the weather in Lisbon? Use the get_weather tool, then summarize it in one sentence."
+);
+
+console.log(result.data);      // { summary: "It's 18°C and cloudy in Lisbon." }
+console.log(result.toolCalls); // [{ type: "tool-call", call: { name: "get_weather", args: { city: "Lisbon" } }, result: {...} }]
+```
+
+`ToolDefinition.parameters` reuses the same `SchemaInput` machinery as everywhere else in shapecraft (Zod or raw `{ jsonSchema }` - `pattern`/`validate`/`xml` aren't valid tool-parameter shapes and throw clearly if used). The loop runs until the model stops requesting tools, then extracts + validates the final answer through an ordinary `generate()` call over the transcript - the same one-shot extraction pattern `turnaround` mode uses at its completion sentinel, so the structured-answer guarantee is identical to any standalone `generate()` call, not a weaker tool-calling-specific check.
+
+What this does and doesn't guarantee:
+
+- **Tool argument validation is real and structural** - each call's `args` goes through the exact same `SchemaInput` validation pipeline as any `generate()` call, before the handler ever runs. A model producing malformed args fails that step, gets fed back as an error the model can retry from - it never silently reaches your handler.
+- **The final answer is validated exactly as strongly as a standalone `generate()` call** with that schema - tool-calling is a different path *to* the same validated-answer guarantee, not a weaker one.
+- **Tool *selection* is not validated.** Nothing checks the model picked the "right" tool, or that it should have called one at all - that's inherent model behavior, same structural-vs-semantic gap this README already documents elsewhere.
+- **A tool handler's own correctness is entirely your responsibility.** shapecraft only guarantees the handler's *return value* gets fed back to the model as-is.
+- **No loop-prevention beyond `maxTurns`** (default 10) - a model that keeps requesting tools forever throws `MaxToolTurnsExceededError`. A handler that throws aborts immediately with `ToolExecutionError` instead (a business-logic failure, never retried the way a bad argument is - re-prompting the model can't fix a broken handler).
+
+Available today on `openai()`, `groq()`, `anthropic()`, `ollama()`. Not yet on `fireworks()`/`mistral()`/`openRouter()`/`gemini()`/`deepseek()`/`llamaCpp()` (different branches - natural follow-up once merged). Non-streaming in v1, same reasoning `runAgents()` gives for skipping streaming.
+
 ## What shapecraft guarantees — and what it doesn't
 
 Every mechanism above (`native`, `constrained`, `best-effort` + retry) targets one thing: **the output is structurally valid** — it parses, the types match, required fields are present and non-empty. That's a real, load-bearing guarantee: it's the difference between code that can trust `result.data.age` is a `number` versus code that has to defensively re-check everything the model says.

--- a/README.md
+++ b/README.md
@@ -800,7 +800,7 @@ What this does and doesn't guarantee:
 - **A tool handler's own correctness is entirely your responsibility.** shapecraft only guarantees the handler's *return value* gets fed back to the model as-is.
 - **No loop-prevention beyond `maxTurns`** (default 10) - a model that keeps requesting tools forever throws `MaxToolTurnsExceededError`. A handler that throws aborts immediately with `ToolExecutionError` instead (a business-logic failure, never retried the way a bad argument is - re-prompting the model can't fix a broken handler).
 
-Available on `openai()`, `groq()`, `anthropic()`, `ollama()`, `fireworks()`, `mistral()`, `openRouter()` and `deepseek()`. Not on `gemini()` (routed through `@google/genai`, not an OpenAI-shaped chat/completions endpoint) or `llamaCpp()` (local GGUF inference, no tools API). Check `model.capabilities.toolCalling` rather than hardcoding that list. Non-streaming in v1, same reasoning `runAgents()` gives for skipping streaming.
+Available on every cloud backend: `openai()`, `groq()`, `anthropic()`, `ollama()`, `fireworks()`, `mistral()`, `openRouter()`, `deepseek()` and `gemini()`. The only exception is `llamaCpp()` - local GGUF inference exposes no tools API. Check `model.capabilities.toolCalling` rather than hardcoding that list. Non-streaming in v1, same reasoning `runAgents()` gives for skipping streaming.
 
 ## What shapecraft guarantees — and what it doesn't
 

--- a/examples/tool-calling.ts
+++ b/examples/tool-calling.ts
@@ -1,0 +1,31 @@
+/**
+ * Example: Native tool calling - the model requests a tool, gets the result,
+ * then answers. Uses the provider's own tool-calling API (OpenAI/Groq/
+ * Anthropic/Ollama each have a different wire shape under the hood), not
+ * shapecraft's own prompted skill-dispatch mechanism.
+ */
+import { generateWithTools, anthropic } from "@aviasole/shapecraft";
+import { z } from "zod";
+import type { ToolDefinition } from "@aviasole/shapecraft";
+
+const model = anthropic({ model: "claude-haiku-4-5-20251001" });
+
+const getWeather: ToolDefinition = {
+  name: "get_weather",
+  description: "Get current weather for a city",
+  parameters: z.object({ city: z.string() }),
+  handler: async ({ city }: { city: string }) => {
+    // A real handler would call a real weather API - hardcoded here for the example.
+    return { city, tempC: 18, condition: "cloudy" };
+  },
+};
+
+const result = await generateWithTools(
+  model,
+  [getWeather],
+  z.object({ summary: z.string() }),
+  "What's the weather in Lisbon? Use the get_weather tool, then summarize it in one sentence."
+);
+
+console.log(result.data); // { summary: "It's 18°C and cloudy in Lisbon." }
+console.log(result.toolCalls); // [{ type: "tool-call", call: { name: "get_weather", args: { city: "Lisbon" } }, result: { city: "Lisbon", tempC: 18, condition: "cloudy" } }]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@aviasole/shapecraft",
-      "version": "2.7.0",
+      "version": "2.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "fast-xml-parser": "^5.9.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aviasole/shapecraft",
-  "version": "2.7.0",
+  "version": "2.8.0",
   "description": "Structured output generation for LLMs in Node.js — token-level constraints for local models, native JSON modes for cloud APIs",
   "author": "Aviasole Technologies",
   "license": "Apache-2.0",

--- a/src/backends/anthropic.ts
+++ b/src/backends/anthropic.ts
@@ -1,6 +1,49 @@
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
+import { toolParametersJsonSchema } from "../core/tools.js";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toAnthropicTools(tools: ToolDefinition[]): any[] {
+  return tools.map((t) => ({ name: t.name, description: t.description, input_schema: toolParametersJsonSchema(t.parameters) }));
+}
+
+/**
+ * Anthropic has no separate "tool" role - a tool result is sent back as a
+ * "user" message with a `tool_result` content block, and every tool_result
+ * for the same turn must be combined into ONE user message, not one each.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toAnthropicMessages(messages: ChatMessage[]): any[] {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const result: any[] = [];
+
+  for (const m of messages) {
+    if (m.role === "tool") {
+      const block = { type: "tool_result", tool_use_id: m.toolCallId, content: m.content };
+      const last = result[result.length - 1];
+      if (last?.role === "user" && Array.isArray(last.content) && last.content[0]?.type === "tool_result") {
+        last.content.push(block);
+      } else {
+        result.push({ role: "user", content: [block] });
+      }
+      continue;
+    }
+
+    if (m.role === "assistant" && m.toolCalls) {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const content: any[] = [];
+      if (m.content) content.push({ type: "text", text: m.content });
+      for (const c of m.toolCalls) content.push({ type: "tool_use", id: c.id, name: c.name, input: c.args });
+      result.push({ role: "assistant", content });
+      continue;
+    }
+
+    result.push({ role: m.role, content: m.content });
+  }
+
+  return result;
+}
 
 export interface AnthropicBackendOptions {
   model?: string;
@@ -23,7 +66,7 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
   return {
     id: `anthropic:${modelId}`,
     guaranteeLevel: "best-effort",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const anthropicClient = await client();
@@ -83,6 +126,34 @@ export function anthropic(options: AnthropicBackendOptions = {}): ShapecraftMode
           yield event.delta.text as string;
         }
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string): Promise<ToolCallResponse> {
+      const anthropicClient = await client();
+
+      const response = await anthropicClient.messages.create({
+        model: modelId,
+        max_tokens: 4096,
+        system: systemPrompt,
+        messages: toAnthropicMessages(messages),
+        tools: toAnthropicTools(tools),
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const blocks = response.content as any[];
+      const text = blocks
+        .filter((b) => b.type === "text")
+        .map((b) => b.text)
+        .join("");
+      const toolUseBlocks = blocks.filter((b) => b.type === "tool_use");
+      const toolCalls = toolUseBlocks.length
+        ? toolUseBlocks.map((b) => ({ id: b.id as string, name: b.name as string, args: b.input }))
+        : undefined;
+
+      return {
+        ...(text ? { content: text } : {}),
+        ...(toolCalls ? { toolCalls } : {}),
+      };
     },
   };
 }

--- a/src/backends/deepseek.ts
+++ b/src/backends/deepseek.ts
@@ -1,6 +1,7 @@
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
+import { openAiCompatibleToolCall } from "../core/tools.js";
 import { isXmlInput, isGbnfInput } from "../core/validate.js";
 
 function wantsJsonMode(schema: SchemaInput): boolean {
@@ -52,7 +53,7 @@ export function deepseek(options: DeepseekBackendOptions = {}): ShapecraftModel 
   return {
     id: `deepseek:${modelId}`,
     guaranteeLevel: "native",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const deepseekClient = await client();
@@ -116,6 +117,10 @@ export function deepseek(options: DeepseekBackendOptions = {}): ShapecraftModel 
         const delta = chunk.choices?.[0]?.delta?.content;
         if (delta) yield delta;
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string): Promise<ToolCallResponse> {
+      return openAiCompatibleToolCall(await client(), modelId, messages, tools, systemPrompt);
     },
   };
 }

--- a/src/backends/fireworks.ts
+++ b/src/backends/fireworks.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema, isGbnfInput } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
+import { openAiCompatibleToolCall } from "../core/tools.js";
 
 export interface FireworksBackendOptions {
   model?: string;
@@ -56,7 +57,7 @@ export function fireworks(options: FireworksBackendOptions = {}): ShapecraftMode
   return {
     id: `fireworks:${modelId}`,
     guaranteeLevel: "native",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const fireworksClient = await client();
@@ -120,6 +121,10 @@ export function fireworks(options: FireworksBackendOptions = {}): ShapecraftMode
         const delta = chunk.choices?.[0]?.delta?.content;
         if (delta) yield delta;
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string): Promise<ToolCallResponse> {
+      return openAiCompatibleToolCall(await client(), modelId, messages, tools, systemPrompt);
     },
   };
 }

--- a/src/backends/gemini.ts
+++ b/src/backends/gemini.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema, isGbnfInput } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
+import { toolParametersJsonSchema } from "../core/tools.js";
 
 export interface GeminiBackendOptions {
   model?: string;
@@ -38,6 +39,58 @@ function responseConfigFor(schema: SchemaInput): ResponseConfig {
 }
 
 /**
+ * Gemini can't reuse `openAiCompatibleToolCall()` - `@google/genai` models a tool
+ * turn as `functionCall`/`functionResponse` Parts inside `contents`, not as
+ * OpenAI's flat `tool_calls` array plus `tool`-role messages. Two shape
+ * mismatches have to be bridged here:
+ *  - A `functionResponse` Part carries the function *name*, but a `"tool"`
+ *    ChatMessage only carries `toolCallId`, so names are recovered from the
+ *    assistant turn that requested the call.
+ *  - `response` must be a JSON object; a handler returning an array or a scalar
+ *    gets wrapped rather than sent as-is and rejected.
+ *  - Gemini rejects a replayed `functionCall` Part that has lost its
+ *    `thoughtSignature` ("required for tools to work correctly", HTTP 400). That
+ *    signature is an opaque provider token with nowhere to live on the shared
+ *    `ToolCall` type, so it is stashed per model instance and reattached here.
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toGeminiContents(messages: ChatMessage[], thoughtSignatures: Map<string, string>): any[] {
+  const nameByCallId = new Map<string, string>();
+  for (const m of messages) {
+    for (const call of m.toolCalls ?? []) nameByCallId.set(call.id, call.name);
+  }
+
+  return messages.map((m) => {
+    if (m.role === "tool") {
+      const name = (m.toolCallId && nameByCallId.get(m.toolCallId)) || m.toolCallId || "unknown";
+      let response: Record<string, unknown>;
+      try {
+        const parsed: unknown = JSON.parse(m.content);
+        response = typeof parsed === "object" && parsed !== null && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : { result: parsed };
+      } catch {
+        response = { result: m.content };
+      }
+      return { role: "user", parts: [{ functionResponse: { name, response } }] };
+    }
+
+    if (m.toolCalls?.length) {
+      return {
+        role: "model",
+        parts: m.toolCalls.map((call) => {
+          const signature = thoughtSignatures.get(call.id);
+          return {
+            functionCall: { name: call.name, args: (call.args ?? {}) as Record<string, unknown> },
+            ...(signature ? { thoughtSignature: signature } : {}),
+          };
+        }),
+      };
+    }
+
+    return { role: m.role === "assistant" ? "model" : "user", parts: [{ text: m.content }] };
+  });
+}
+
+/**
  * Google Gemini via the official `@google/genai` SDK - not the OpenAI-compatible
  * endpoint, since that's a migration bridge for OpenAI users rather than Gemini's
  * primary integration path, and doesn't expose `responseJsonSchema` (plain JSON
@@ -52,6 +105,11 @@ export function gemini(options: GeminiBackendOptions = {}): ShapecraftModel {
   // version string that can get deprecated out from under a hardcoded default.
   const modelId = options.model ?? "gemini-flash-latest";
 
+  // Opaque per-call tokens Gemini requires back on the next turn, keyed by the
+  // ToolCall id we hand to generateWithTools(). Scoped to this model instance so
+  // it lives exactly as long as the conversation that produced the signatures.
+  const thoughtSignatures = new Map<string, string>();
+
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   async function client(): Promise<any> {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -65,7 +123,7 @@ export function gemini(options: GeminiBackendOptions = {}): ShapecraftModel {
   return {
     id: `gemini:${modelId}`,
     guaranteeLevel: "native",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const ai = await client();
@@ -130,6 +188,58 @@ export function gemini(options: GeminiBackendOptions = {}): ShapecraftModel {
         const delta = chunk.text;
         if (delta) yield delta;
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string, callOptions?: ModelCallOptions): Promise<ToolCallResponse> {
+      const ai = await client();
+
+      const response = await ai.models.generateContent({
+        model: modelId,
+        contents: toGeminiContents(messages, thoughtSignatures),
+        config: {
+          ...(systemPrompt ? { systemInstruction: systemPrompt } : {}),
+          tools: [
+            {
+              functionDeclarations: tools.map((t) => ({
+                name: t.name,
+                description: t.description,
+                // parametersJsonSchema takes plain JSON Schema; the older `parameters`
+                // field would need Gemini's Type-enum OpenAPI subset instead. Same
+                // distinction as responseJsonSchema vs responseSchema above.
+                parametersJsonSchema: toolParametersJsonSchema(t.parameters),
+              })),
+            },
+          ],
+          ...(callOptions?.signal ? { abortSignal: callOptions.signal } : {}),
+        },
+      });
+
+      // Read the raw Parts rather than the response.functionCalls convenience
+      // getter: the getter drops each call's sibling thoughtSignature, which the
+      // next turn must send back. Falls back to the getter when candidates are
+      // absent, so a minimal stub still works.
+      type GeminiPart = { functionCall?: { id?: string; name?: string; args?: Record<string, unknown> }; thoughtSignature?: string };
+      const parts = (response.candidates?.[0]?.content?.parts ?? []) as GeminiPart[];
+      const fromParts = parts.filter((p) => p.functionCall?.name);
+      const calls: Array<{ id?: string; name?: string; args?: Record<string, unknown>; thoughtSignature?: string }> = fromParts.length
+        ? fromParts.map((p) => ({ ...p.functionCall, thoughtSignature: p.thoughtSignature }))
+        : ((response.functionCalls ?? []) as Array<{ id?: string; name?: string; args?: Record<string, unknown> }>).filter((c) => c.name);
+
+      // Gemini's FunctionCall.id is optional in the SDK type (and unset on some
+      // surfaces, e.g. Vertex) while generateWithTools() correlates each result
+      // back by id - so synthesize a stable per-turn one when it is absent.
+      const toolCalls = calls.map((c, i) => {
+        const id = c.id ?? `${modelId}-call-${i}-${c.name}`;
+        if (c.thoughtSignature) thoughtSignatures.set(id, c.thoughtSignature);
+        return { id, name: c.name as string, args: c.args ?? {} };
+      });
+
+      const text: string = response.text ?? "";
+
+      return {
+        ...(text ? { content: text } : {}),
+        ...(toolCalls.length > 0 ? { toolCalls } : {}),
+      };
     },
   };
 }

--- a/src/backends/groq.ts
+++ b/src/backends/groq.ts
@@ -1,7 +1,8 @@
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { buildStructuredPrompt } from "../core/schema.js";
 import { parseAndValidate } from "../core/parse.js";
 import { isXmlInput, isGbnfInput } from "../core/validate.js";
+import { openAiCompatibleToolCall } from "../core/tools.js";
 
 function wantsJsonMode(schema: SchemaInput): boolean {
   // XML and GBNF output free-form strings, not JSON — Groq rejects json_object
@@ -30,7 +31,7 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
   return {
     id: `groq:${modelId}`,
     guaranteeLevel: "native",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const groqClient = await client();
@@ -95,6 +96,10 @@ export function groq(options: GroqBackendOptions = {}): ShapecraftModel {
         const delta = chunk.choices?.[0]?.delta?.content;
         if (delta) yield delta;
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string): Promise<ToolCallResponse> {
+      return openAiCompatibleToolCall(await client(), modelId, messages, tools, systemPrompt);
     },
   };
 }

--- a/src/backends/llamaCpp.ts
+++ b/src/backends/llamaCpp.ts
@@ -48,6 +48,11 @@ export function llamaCpp(options: LlamaCppBackendOptions): ShapecraftModel {
   return {
     id: `llamacpp:${options.modelPath}`,
     guaranteeLevel: "constrained",
+    // The only backend that reports streaming/toolCalling false: local GGUF
+    // inference here exposes no token-delta iterator (the core falls back to a
+    // one-shot generate()) and no tools API. skillDispatch is true for the same
+    // reason it is everywhere - it only needs generate().
+    capabilities: { streaming: false, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string): Promise<T> {
       // Fail fast on a malformed grammar before loading a multi-GB model.

--- a/src/backends/mistral.ts
+++ b/src/backends/mistral.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema, isGbnfInput } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
+import { openAiCompatibleToolCall } from "../core/tools.js";
 
 export interface MistralBackendOptions {
   model?: string;
@@ -56,7 +57,7 @@ export function mistral(options: MistralBackendOptions = {}): ShapecraftModel {
   return {
     id: `mistral:${modelId}`,
     guaranteeLevel: "native",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const mistralClient = await client();
@@ -123,6 +124,10 @@ export function mistral(options: MistralBackendOptions = {}): ShapecraftModel {
         const delta = chunk.choices?.[0]?.delta?.content;
         if (delta) yield delta;
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string): Promise<ToolCallResponse> {
+      return openAiCompatibleToolCall(await client(), modelId, messages, tools, systemPrompt);
     },
   };
 }

--- a/src/backends/ollama.ts
+++ b/src/backends/ollama.ts
@@ -1,9 +1,30 @@
 import { z } from "zod";
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
 import { combineSignals } from "../core/timeout.js";
+import { toOpenAiCompatibleTools } from "../core/tools.js";
+
+// Verified live (2026-07-16, gemma4:e2b): Ollama's tool_calls[].function.arguments
+// is already a parsed object, NOT a JSON string like OpenAI/Groq - do not JSON.parse it.
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function toOllamaMessages(messages: ChatMessage[], systemPrompt?: string): any[] {
+  return [
+    ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+    ...messages.map((m) => {
+      if (m.role === "tool") return { role: "tool" as const, tool_call_id: m.toolCallId, content: m.content };
+      if (m.toolCalls) {
+        return {
+          role: "assistant" as const,
+          content: m.content,
+          tool_calls: m.toolCalls.map((c) => ({ id: c.id, function: { name: c.name, arguments: c.args } })),
+        };
+      }
+      return { role: m.role, content: m.content };
+    }),
+  ];
+}
 
 export interface OllamaBackendOptions {
   model: string;
@@ -31,7 +52,7 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
   return {
     id: `ollama:${options.model}`,
     guaranteeLevel: "constrained",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const { system, user } = buildStructuredPrompt(prompt, schema, systemPrompt);
@@ -141,6 +162,40 @@ export function ollama(options: OllamaBackendOptions): ShapecraftModel {
         // the underlying stream instead of leaking a locked reader.
         reader.releaseLock();
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string, callOptions?: ModelCallOptions): Promise<ToolCallResponse> {
+      const response = await fetch(`${host}/api/chat`, {
+        signal: combineSignals(AbortSignal.timeout(timeoutMs), callOptions?.signal) ?? null,
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: options.model,
+          messages: toOllamaMessages(messages, systemPrompt),
+          tools: toOpenAiCompatibleTools(tools),
+          stream: false,
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error(`Ollama error: ${response.status} ${response.statusText}`);
+      }
+
+      const json = (await response.json()) as {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        message?: { content?: string; tool_calls?: any[] };
+      };
+
+      const toolCalls = json.message?.tool_calls?.map((tc) => ({
+        id: tc.id as string,
+        name: tc.function.name as string,
+        args: tc.function.arguments,
+      }));
+
+      return {
+        ...(json.message?.content ? { content: json.message.content } : {}),
+        ...(toolCalls ? { toolCalls } : {}),
+      };
     },
   };
 }

--- a/src/backends/openRouter.ts
+++ b/src/backends/openRouter.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema, isGbnfInput } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
+import { openAiCompatibleToolCall } from "../core/tools.js";
 
 export interface OpenRouterBackendOptions {
   model?: string;
@@ -61,7 +62,7 @@ export function openRouter(options: OpenRouterBackendOptions = {}): ShapecraftMo
   return {
     id: `openrouter:${modelId}`,
     guaranteeLevel: "best-effort",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const openRouterClient = await client();
@@ -125,6 +126,10 @@ export function openRouter(options: OpenRouterBackendOptions = {}): ShapecraftMo
         const delta = chunk.choices?.[0]?.delta?.content;
         if (delta) yield delta;
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string): Promise<ToolCallResponse> {
+      return openAiCompatibleToolCall(await client(), modelId, messages, tools, systemPrompt);
     },
   };
 }

--- a/src/backends/openai.ts
+++ b/src/backends/openai.ts
@@ -1,8 +1,9 @@
 import { z } from "zod";
-import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel } from "../types.js";
+import type { ChatMessage, ModelCallOptions, SchemaInput, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../types.js";
 import { toJsonSchema, buildStructuredPrompt } from "../core/schema.js";
 import { isZodSchema, isGbnfInput } from "../core/validate.js";
 import { parseAndValidate } from "../core/parse.js";
+import { openAiCompatibleToolCall } from "../core/tools.js";
 
 export interface OpenAIBackendOptions {
   model?: string;
@@ -46,7 +47,7 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
   return {
     id: `openai:${modelId}`,
     guaranteeLevel: "native",
-    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: false, skillDispatch: true },
+    capabilities: { streaming: true, chat: true, structuredOutput: true, toolCalling: true, skillDispatch: true },
 
     async generate<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): Promise<T> {
       const openaiClient = await client();
@@ -110,6 +111,10 @@ export function openai(options: OpenAIBackendOptions = {}): ShapecraftModel {
         const delta = chunk.choices?.[0]?.delta?.content;
         if (delta) yield delta;
       }
+    },
+
+    async toolCall(messages: ChatMessage[], tools: ToolDefinition[], systemPrompt?: string): Promise<ToolCallResponse> {
+      return openAiCompatibleToolCall(await client(), modelId, messages, tools, systemPrompt);
     },
   };
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -7,7 +7,26 @@ import { isXmlInput, isGbnfInput, isZodSchema } from "./validate.js";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toJsonSchema(schema: z.ZodType<any>): Record<string, unknown> {
-  // jsonSchema7 (the default target), not openApi3 - openApi3 emits the old OpenAPI
+  // zod-to-json-schema (last updated for Zod v3's internal shape) silently
+  // returns {} for a v4 schema instead of erroring - it doesn't recognize v4's
+  // reworked internals at all. Zod v4 ships its own native z.toJSONSchema(),
+  // which also emits the correct numeric exclusiveMinimum/exclusiveMaximum
+  // form (the third-party package's legacy boolean form was a separate bug).
+  //
+  // zod is an optional peerDependency (">=3.0.0"), so a consumer's schema may
+  // have been built by a *different* zod install than the one bundled here
+  // (dual-package hazard). z4.toJSONSchema() reads a schema's own internal
+  // shape directly rather than calling a method on it, so calling it on a
+  // v3-built schema throws ("Cannot read properties of undefined (reading
+  // 'def')") even though our bundled zod is v4. Detect the schema instance's
+  // own version via its "_zod" marker (present only on v4-built schemas)
+  // instead of trusting which zod happens to be bundled.
+  const isV4Schema = typeof schema === "object" && schema !== null && "_zod" in schema;
+  const zModule = z as unknown as { toJSONSchema?: (s: unknown) => Record<string, unknown> };
+  if (isV4Schema && typeof zModule.toJSONSchema === "function") {
+    return zModule.toJSONSchema(schema);
+  }
+  // jsonSchema7, not the default openApi3 target - openApi3 emits the old OpenAPI
   // 3.0 boolean form for exclusive bounds (`.positive()`/`.negative()`/`.gt()`/`.lt()`)
   // - exclusiveMinimum: true + a separate minimum - instead of the numeric form real
   // JSON Schema requires (exclusiveMinimum: 0). Backends that validate the schema

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -1,0 +1,190 @@
+import type {
+  ChatMessage,
+  SchemaInput,
+  ShapecraftModel,
+  ToolCallOptions,
+  ToolCallResponse,
+  ToolDefinition,
+  ToolResult,
+  ToolTurn,
+} from "../types.js";
+import { MaxToolTurnsExceededError, ToolExecutionError } from "../types.js";
+import { validateOutput, isZodSchema } from "./validate.js";
+import { toJsonSchema } from "./schema.js";
+import { generate } from "./generate.js";
+
+/**
+ * Converts a tool's `parameters: SchemaInput` into the plain JSON-schema shape
+ * every provider's native tools API expects. Only Zod and raw `{ jsonSchema }`
+ * make sense as a tool's argument signature - `pattern`/`validate`/`xml` have
+ * no sensible representation as a named-parameters object, so those throw
+ * clearly here rather than silently producing a broken tool definition.
+ */
+export function toolParametersJsonSchema(schema: SchemaInput): Record<string, unknown> {
+  if (isZodSchema(schema)) return toJsonSchema(schema);
+  if ("jsonSchema" in (schema as object)) return (schema as { jsonSchema: Record<string, unknown> }).jsonSchema;
+  throw new Error("Tool parameters must be a Zod schema or { jsonSchema } - pattern/validate/xml are not valid tool parameter shapes.");
+}
+
+/**
+ * Shared by every OpenAI-wire-format backend (openai(), groq(), and - once
+ * their branches merge - fireworks()/mistral()/openRouter()/deepseek(), which
+ * all use the same `{ type: "function", function: {...} }` tools shape).
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toOpenAiCompatibleTools(tools: ToolDefinition[]): any[] {
+  return tools.map((t) => ({
+    type: "function",
+    function: { name: t.name, description: t.description, parameters: toolParametersJsonSchema(t.parameters) },
+  }));
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export function toOpenAiCompatibleMessages(messages: ChatMessage[], systemPrompt?: string): any[] {
+  return [
+    ...(systemPrompt ? [{ role: "system" as const, content: systemPrompt }] : []),
+    ...messages.map((m) => {
+      if (m.role === "tool") return { role: "tool" as const, tool_call_id: m.toolCallId, content: m.content };
+      if (m.toolCalls) {
+        return {
+          role: "assistant" as const,
+          content: m.content || null,
+          tool_calls: m.toolCalls.map((c) => ({
+            id: c.id,
+            type: "function" as const,
+            function: { name: c.name, arguments: JSON.stringify(c.args) },
+          })),
+        };
+      }
+      return { role: m.role, content: m.content };
+    }),
+  ];
+}
+
+/**
+ * One tool-calling turn against any OpenAI-wire-format chat completions
+ * client (openai(), groq(), and - once their branches merge -
+ * fireworks()/mistral()/openRouter()/deepseek() all share this exact request/
+ * response shape, differing only in which SDK client hits it).
+ */
+export async function openAiCompatibleToolCall(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  client: any,
+  modelId: string,
+  messages: ChatMessage[],
+  tools: ToolDefinition[],
+  systemPrompt?: string
+): Promise<ToolCallResponse> {
+  const response = await client.chat.completions.create({
+    model: modelId,
+    messages: toOpenAiCompatibleMessages(messages, systemPrompt),
+    tools: toOpenAiCompatibleTools(tools),
+  });
+
+  const message = response.choices[0]?.message;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const toolCalls = (message?.tool_calls as any[] | undefined)?.map((tc) => ({
+    id: tc.id as string,
+    name: tc.function.name as string,
+    args: JSON.parse(tc.function.arguments || "{}"),
+  }));
+
+  return {
+    ...(message?.content ? { content: message.content } : {}),
+    ...(toolCalls ? { toolCalls } : {}),
+  };
+}
+
+function transcriptToText(messages: ChatMessage[]): string {
+  return messages
+    .map((m) => {
+      if (m.role === "tool") return `Tool result: ${m.content}`;
+      return `${m.role === "user" ? "User" : "Assistant"}: ${m.content}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Native tool-calling loop: passes the running message history + tool
+ * definitions to the model's own `toolCall()` turn, executes any requested
+ * tool(s) locally (validating each call's args against that tool's own
+ * `parameters` schema first), feeds results back, and repeats until the model
+ * stops requesting tools. The final answer is then extracted + validated
+ * through an ordinary `generate()` call over the transcript - the same
+ * one-shot extraction pattern `turnaround.ts` uses at its completion sentinel,
+ * so the structured-answer guarantee is identical to any standalone
+ * `generate()` call, not a weaker tool-calling-specific check.
+ *
+ * A bad tool call from the model (unknown tool name, or args that fail that
+ * tool's own schema) is fed back as a "tool" error message so the model can
+ * retry - recoverable, since re-prompting can fix it. A handler itself
+ * throwing is NOT recoverable this way - it aborts immediately via
+ * `ToolExecutionError`, since re-prompting the model can't fix a broken handler.
+ */
+export async function generateWithTools<T>(
+  model: ShapecraftModel,
+  tools: ToolDefinition[],
+  schema: SchemaInput<T>,
+  prompt: string,
+  options: ToolCallOptions = {}
+): Promise<ToolResult<T>> {
+  if (!model.toolCall) {
+    throw new Error(`Model "${model.id}" does not support tool calling (missing toolCall()).`);
+  }
+
+  const maxTurns = options.maxTurns ?? 10;
+  const toolsByName = new Map(tools.map((t) => [t.name, t]));
+  const messages: ChatMessage[] = [{ role: "user", content: prompt }];
+  const trace: ToolTurn[] = [];
+
+  for (let turn = 1; turn <= maxTurns; turn++) {
+    const reply = await model.toolCall(messages, tools, options.systemPrompt);
+
+    if (!reply.toolCalls || reply.toolCalls.length === 0) {
+      messages.push({ role: "assistant", content: reply.content ?? "" });
+      const transcript = transcriptToText(messages);
+      const extracted = await generate<T>(
+        model,
+        schema,
+        `Extract the structured data from the following conversation:\n\n${transcript}`,
+        options.maxRetries !== undefined ? { maxRetries: options.maxRetries } : {}
+      );
+      return { data: extracted.data, toolCalls: trace, attempts: extracted.attempts };
+    }
+
+    messages.push({ role: "assistant", content: reply.content ?? "", toolCalls: reply.toolCalls });
+
+    for (const call of reply.toolCalls) {
+      const tool = toolsByName.get(call.name);
+
+      if (!tool) {
+        const error = `Unknown tool "${call.name}" - available tools: ${tools.map((t) => t.name).join(", ")}`;
+        trace.push({ type: "tool-error", call, error });
+        messages.push({ role: "tool", content: JSON.stringify({ error }), toolCallId: call.id });
+        continue;
+      }
+
+      let validatedArgs: unknown;
+      try {
+        validatedArgs = validateOutput(call.args, tool.parameters);
+      } catch (err) {
+        const error = `Invalid arguments for tool "${call.name}": ${err instanceof Error ? err.message : String(err)}`;
+        trace.push({ type: "tool-error", call, error });
+        messages.push({ role: "tool", content: JSON.stringify({ error }), toolCallId: call.id });
+        continue;
+      }
+
+      let result: unknown;
+      try {
+        result = await tool.handler(validatedArgs);
+      } catch (err) {
+        throw new ToolExecutionError(call.name, err);
+      }
+
+      trace.push({ type: "tool-call", call, result });
+      messages.push({ role: "tool", content: JSON.stringify(result), toolCallId: call.id });
+    }
+  }
+
+  throw new MaxToolTurnsExceededError(maxTurns);
+}

--- a/src/core/tools.ts
+++ b/src/core/tools.ts
@@ -27,9 +27,11 @@ export function toolParametersJsonSchema(schema: SchemaInput): Record<string, un
 }
 
 /**
- * Shared by every OpenAI-wire-format backend (openai(), groq(), and - once
- * their branches merge - fireworks()/mistral()/openRouter()/deepseek(), which
- * all use the same `{ type: "function", function: {...} }` tools shape).
+ * Shared by every OpenAI-wire-format backend - openai(), groq(), fireworks(),
+ * mistral(), openRouter() and deepseek() all use the same
+ * `{ type: "function", function: {...} }` tools shape. gemini() is the one
+ * backend that can't reuse this: it goes through @google/genai rather than an
+ * OpenAI-shaped chat/completions endpoint.
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function toOpenAiCompatibleTools(tools: ToolDefinition[]): any[] {
@@ -62,10 +64,10 @@ export function toOpenAiCompatibleMessages(messages: ChatMessage[], systemPrompt
 }
 
 /**
- * One tool-calling turn against any OpenAI-wire-format chat completions
- * client (openai(), groq(), and - once their branches merge -
- * fireworks()/mistral()/openRouter()/deepseek() all share this exact request/
- * response shape, differing only in which SDK client hits it).
+ * One tool-calling turn against any OpenAI-wire-format chat completions client.
+ * openai(), groq(), fireworks(), mistral(), openRouter() and deepseek() all
+ * share this exact request/response shape, differing only in which SDK client
+ * hits it.
  */
 export async function openAiCompatibleToolCall(
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export { SkillRegistry, generateSkillCall, runSkill, runSkillLoop } from "./core
 export { createClient } from "./core/client.js";
 export { composeMiddleware, loggingMiddleware } from "./core/middleware.js";
 export { checkJsonSchema, runValidationPipeline } from "./core/validate.js";
+export { generateWithTools, toolParametersJsonSchema } from "./core/tools.js";
 
 export * from "./backends/index.js";
 
@@ -41,6 +42,12 @@ export type {
   BatchItem,
   BatchResult,
   GenerateBatchOptions,
+  ToolCall,
+  ToolCallResponse,
+  ToolDefinition,
+  ToolTurn,
+  ToolCallOptions,
+  ToolResult,
 } from "./types.js";
 
 export type { CreateClientOptions, ShapecraftClient } from "./core/client.js";
@@ -54,4 +61,6 @@ export {
   TimeoutError,
   SkillExecutionError,
   MaxSkillTurnsExceededError,
+  MaxToolTurnsExceededError,
+  ToolExecutionError,
 } from "./types.js";

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,8 +43,58 @@ export type XmlInput = {
 export type SchemaInput<T = unknown> = z.ZodType<T> | JsonSchemaInput | PatternInput | ValidatorInput | XmlInput | GbnfInput;
 
 export interface ChatMessage {
-  role: "user" | "assistant";
+  role: "user" | "assistant" | "tool";
   content: string;
+  /** Present on an assistant message that requested tool(s) instead of/alongside a final answer. */
+  toolCalls?: ToolCall[];
+  /** Present on a "tool" role message - correlates the result back to the call that produced it. */
+  toolCallId?: string;
+}
+
+/** A model's request to invoke one named tool with (already-parsed, not-yet-validated) arguments. */
+export interface ToolCall {
+  id: string;
+  name: string;
+  args: unknown;
+}
+
+/** Reply from `ShapecraftModel.toolCall()` - either a final answer, or one/more tool requests, never both meaningfully at once for the loop's purposes (toolCalls present means "not done yet"). */
+export interface ToolCallResponse {
+  content?: string;
+  toolCalls?: ToolCall[];
+}
+
+/**
+ * A plain `{ name, parameters, handler }` descriptor - not a class. `parameters`
+ * reuses the existing `SchemaInput` machinery, so tool arguments are validated
+ * through the same structural pipeline as any other shapecraft schema.
+ */
+export interface ToolDefinition<Args = unknown, Result = unknown> {
+  name: string;
+  description?: string;
+  parameters: SchemaInput<Args>;
+  handler: (args: Args) => Result | Promise<Result>;
+}
+
+/** One completed tool invocation in a `generateWithTools()` trace. */
+export type ToolTurn =
+  | { type: "tool-call"; call: ToolCall; result: unknown }
+  | { type: "tool-error"; call: ToolCall; error: string };
+
+export interface ToolCallOptions {
+  systemPrompt?: string;
+  /** Loop guard - throws MaxToolTurnsExceededError beyond this many turns. Default 10. */
+  maxTurns?: number;
+  /** Forwarded to the final structured-extraction generate() call once the model stops requesting tools. */
+  maxRetries?: number;
+}
+
+export interface ToolResult<T> {
+  data: T;
+  /** Every tool call made across the loop, in order. */
+  toolCalls: ToolTurn[];
+  /** Attempts taken by the final extraction generate() call (not the tool-calling turns themselves). */
+  attempts: number;
 }
 
 /**
@@ -103,6 +153,19 @@ export interface ShapecraftModel {
    * Absence ⇒ the core falls back to one-shot `generate()`.
    */
   generateStream?<T>(prompt: string, schema: SchemaInput<T>, systemPrompt?: string, callOptions?: ModelCallOptions): AsyncIterable<string>;
+  /**
+   * One native tool-calling turn - passes the running message history + tool
+   * definitions to the provider's own tool-calling API and returns either a
+   * final answer (`content`) or one/more tool requests (`toolCalls`). Absence
+   * ⇒ `capabilities.toolCalling` stays `false` and `generateWithTools()` throws
+   * immediately rather than silently degrading.
+   */
+  toolCall?(
+    messages: ChatMessage[],
+    tools: ToolDefinition[],
+    systemPrompt?: string,
+    callOptions?: ModelCallOptions
+  ): Promise<ToolCallResponse>;
 }
 
 /**
@@ -241,6 +304,28 @@ export class MaxTurnsExceededError extends Error {
   constructor(public readonly turns: number) {
     super(`Conversation did not complete after ${turns} turns`);
     this.name = "MaxTurnsExceededError";
+  }
+}
+
+export class MaxToolTurnsExceededError extends Error {
+  constructor(public readonly turns: number) {
+    super(`Tool-calling loop did not complete after ${turns} turns`);
+    this.name = "MaxToolTurnsExceededError";
+  }
+}
+
+/**
+ * A tool's own handler threw - a business-logic failure, not a structural one.
+ * Never retried the way a `SchemaViolationError` is (re-prompting the model
+ * wouldn't fix a broken handler), so `generateWithTools()` aborts immediately.
+ */
+export class ToolExecutionError extends Error {
+  constructor(
+    public readonly toolName: string,
+    public readonly cause: unknown
+  ) {
+    super(`Tool "${toolName}" handler threw: ${cause instanceof Error ? cause.message : String(cause)}`);
+    this.name = "ToolExecutionError";
   }
 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -124,7 +124,12 @@ export interface ModelCapabilities {
   streaming: boolean;
   chat: boolean;
   structuredOutput: boolean;
-  /** Native provider function-calling (OpenAI/Anthropic-style `tools`). Not yet built by any backend. */
+  /**
+   * Native provider function-calling (OpenAI/Anthropic-style `tools`), driving
+   * `generateWithTools()`. True wherever the backend implements `toolCall()`.
+   * `llamaCpp()` is the one backend without it - local GGUF inference exposes no
+   * tools API - so check this flag rather than assuming.
+   */
   toolCalling: boolean;
   /**
    * Skill-based dispatch via `generateSkillCall()`/`runSkillLoop()` — built entirely

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -20,6 +20,17 @@ describe("ShapecraftModel.capabilities", () => {
     ["groq", groq({ model: "llama-3.3-70b-versatile" })],
     ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
     ["ollama", ollama({ model: "llama3.2" })],
+  ])("%s exposes streaming/chat/structuredOutput/toolCalling/skillDispatch true", (_name, model) => {
+    expect(model.capabilities).toEqual({
+      streaming: true,
+      chat: true,
+      structuredOutput: true,
+      toolCalling: true,
+      skillDispatch: true,
+    });
+  });
+
+  it.each([
     ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
     ["mistral", mistral({ model: "mistral-large-latest" })],
     ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -15,12 +15,20 @@ import { mockModel } from "./helpers/index.js";
 const PersonSchema = z.object({ name: z.string(), age: z.number() });
 
 describe("ShapecraftModel.capabilities", () => {
+  // Split by toolCalling. Every backend on the OpenAI wire format shares the
+  // openAiCompatibleToolCall() helper; anthropic and ollama have their own
+  // native implementations. gemini is the lone holdout - it goes through
+  // @google/genai, not an OpenAI-shaped chat/completions endpoint.
   it.each([
     ["openai", openai({ model: "gpt-4o-mini" })],
     ["groq", groq({ model: "llama-3.3-70b-versatile" })],
     ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
     ["ollama", ollama({ model: "llama3.2" })],
-  ])("%s exposes streaming/chat/structuredOutput/toolCalling/skillDispatch true", (_name, model) => {
+    ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
+    ["mistral", mistral({ model: "mistral-large-latest" })],
+    ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
+    ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
+  ])("%s exposes streaming/chat/structuredOutput/skillDispatch/toolCalling true", (_name, model) => {
     expect(model.capabilities).toEqual({
       streaming: true,
       chat: true,
@@ -30,21 +38,18 @@ describe("ShapecraftModel.capabilities", () => {
     });
   });
 
-  it.each([
-    ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
-    ["mistral", mistral({ model: "mistral-large-latest" })],
-    ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
-    ["gemini", gemini({ model: "gemini-flash-latest" })],
-    ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
-  ])("%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false", (_name, model) => {
-    expect(model.capabilities).toEqual({
-      streaming: true,
-      chat: true,
-      structuredOutput: true,
-      toolCalling: false,
-      skillDispatch: true,
-    });
-  });
+  it.each([["gemini", gemini({ model: "gemini-flash-latest" })]])(
+    "%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false",
+    (_name, model) => {
+      expect(model.capabilities).toEqual({
+        streaming: true,
+        chat: true,
+        structuredOutput: true,
+        toolCalling: false,
+        skillDispatch: true,
+      });
+    }
+  );
 
   it.each([
     ["openai", openai({ model: "gpt-4o-mini" })],

--- a/tests/capabilities.test.ts
+++ b/tests/capabilities.test.ts
@@ -10,15 +10,15 @@ import { mistral } from "../src/backends/mistral.js";
 import { openRouter } from "../src/backends/openRouter.js";
 import { gemini } from "../src/backends/gemini.js";
 import { deepseek } from "../src/backends/deepseek.js";
+import { llamaCpp } from "../src/backends/llamaCpp.js";
 import { mockModel } from "./helpers/index.js";
 
 const PersonSchema = z.object({ name: z.string(), age: z.number() });
 
 describe("ShapecraftModel.capabilities", () => {
-  // Split by toolCalling. Every backend on the OpenAI wire format shares the
-  // openAiCompatibleToolCall() helper; anthropic and ollama have their own
-  // native implementations. gemini is the lone holdout - it goes through
-  // @google/genai, not an OpenAI-shaped chat/completions endpoint.
+  // Every cloud backend now implements toolCall(): the OpenAI-wire-format ones
+  // share openAiCompatibleToolCall(), while anthropic, ollama and gemini each
+  // have their own. llamaCpp is the sole exception, asserted separately below.
   it.each([
     ["openai", openai({ model: "gpt-4o-mini" })],
     ["groq", groq({ model: "llama-3.3-70b-versatile" })],
@@ -28,6 +28,7 @@ describe("ShapecraftModel.capabilities", () => {
     ["mistral", mistral({ model: "mistral-large-latest" })],
     ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
     ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
+    ["gemini", gemini({ model: "gemini-flash-latest" })],
   ])("%s exposes streaming/chat/structuredOutput/skillDispatch/toolCalling true", (_name, model) => {
     expect(model.capabilities).toEqual({
       streaming: true,
@@ -38,18 +39,72 @@ describe("ShapecraftModel.capabilities", () => {
     });
   });
 
-  it.each([["gemini", gemini({ model: "gemini-flash-latest" })]])(
-    "%s exposes streaming/chat/structuredOutput/skillDispatch true, toolCalling false",
-    (_name, model) => {
-      expect(model.capabilities).toEqual({
-        streaming: true,
-        chat: true,
-        structuredOutput: true,
-        toolCalling: false,
-        skillDispatch: true,
-      });
-    }
-  );
+  it("llamaCpp reports streaming/toolCalling false - no delta iterator, no tools API", () => {
+    expect(llamaCpp({ modelPath: "/nonexistent/model.gguf" }).capabilities).toEqual({
+      streaming: false,
+      chat: true,
+      structuredOutput: true,
+      toolCalling: false,
+      skillDispatch: true,
+    });
+  });
+
+  // Guards the invariant that used to drift: a backend advertising toolCalling
+  // must actually implement toolCall(), and one that doesn't must not claim it.
+  // This is what let fireworks/mistral/openRouter/deepseek sit at `false` while
+  // the OpenAI-compatible helper they could reuse already existed.
+  it.each([
+    ["openai", openai({ model: "gpt-4o-mini" })],
+    ["groq", groq({ model: "llama-3.3-70b-versatile" })],
+    ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
+    ["ollama", ollama({ model: "llama3.2" })],
+    ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
+    ["mistral", mistral({ model: "mistral-large-latest" })],
+    ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
+    ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
+    ["gemini", gemini({ model: "gemini-flash-latest" })],
+    ["llamaCpp", llamaCpp({ modelPath: "/nonexistent/model.gguf" })],
+  ])("%s: capabilities.toolCalling matches whether toolCall() actually exists", (_name, model) => {
+    expect(model.capabilities?.toolCalling).toBe(typeof model.toolCall === "function");
+  });
+
+  it.each([
+    ["openai", openai({ model: "gpt-4o-mini" })],
+    ["groq", groq({ model: "llama-3.3-70b-versatile" })],
+    ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
+    ["ollama", ollama({ model: "llama3.2" })],
+    ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
+    ["mistral", mistral({ model: "mistral-large-latest" })],
+    ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
+    ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
+    ["gemini", gemini({ model: "gemini-flash-latest" })],
+    ["llamaCpp", llamaCpp({ modelPath: "/nonexistent/model.gguf" })],
+  ])("%s: capabilities.streaming matches whether generateStream() actually exists", (_name, model) => {
+    expect(model.capabilities?.streaming).toBe(typeof model.generateStream === "function");
+  });
+
+  // Every backend must declare capabilities at all - llamaCpp shipped without
+  // one, so `model.capabilities` was undefined there while every other backend
+  // returned an object.
+  it.each([
+    ["openai", openai({ model: "gpt-4o-mini" })],
+    ["groq", groq({ model: "llama-3.3-70b-versatile" })],
+    ["anthropic", anthropic({ model: "claude-haiku-4-5-20251001" })],
+    ["ollama", ollama({ model: "llama3.2" })],
+    ["fireworks", fireworks({ model: "accounts/fireworks/models/llama-v3p1-70b-instruct" })],
+    ["mistral", mistral({ model: "mistral-large-latest" })],
+    ["openRouter", openRouter({ model: "openai/gpt-4o-mini" })],
+    ["deepseek", deepseek({ model: "deepseek-v4-flash" })],
+    ["gemini", gemini({ model: "gemini-flash-latest" })],
+    ["llamaCpp", llamaCpp({ modelPath: "/nonexistent/model.gguf" })],
+  ])("%s: declares capabilities, chat() and generate()", (_name, model) => {
+    expect(model.capabilities).toBeDefined();
+    expect(typeof model.generate).toBe("function");
+    expect(typeof model.chat).toBe("function");
+    expect(model.capabilities?.chat).toBe(true);
+    expect(model.capabilities?.skillDispatch).toBe(true);
+    expect(model.id).toBeTruthy();
+  });
 
   it.each([
     ["openai", openai({ model: "gpt-4o-mini" })],

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -5,6 +5,7 @@ import { openai } from "../src/backends/openai.js";
 import { groq } from "../src/backends/groq.js";
 import { anthropic } from "../src/backends/anthropic.js";
 import { ollama } from "../src/backends/ollama.js";
+import { mistral } from "../src/backends/mistral.js";
 import { MaxToolTurnsExceededError, ToolExecutionError } from "../src/types.js";
 import type { ShapecraftModel, ToolCallResponse, ToolDefinition } from "../src/types.js";
 
@@ -160,6 +161,7 @@ const hasOpenAI = !!process.env.OPENAI_API_KEY;
 const hasGroq = !!process.env.GROQ_API_KEY;
 const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
 const hasOllama = !!process.env.OLLAMA_MODEL;
+const hasMistral = !!process.env.MISTRAL_API_KEY;
 
 const getWeatherTool: ToolDefinition = {
   name: "get_weather",
@@ -204,4 +206,14 @@ describe("generateWithTools - Ollama backend (real API)", () => {
   it.skipIf(!hasOllama)("calls get_weather then answers", async () => {
     await realWeatherCheck(ollama({ model: process.env.OLLAMA_MODEL ?? "gemma4:e2b", timeoutMs: 300_000 }));
   }, 480_000);
+});
+
+// mistral() is the one newly-wired OpenAI-compatible backend with a usable key
+// here, so it stands in as the live proof that openAiCompatibleToolCall() works
+// through a non-openai()/groq() client. fireworks()/openRouter()/deepseek() take
+// the identical code path but have no working credentials to verify against.
+describe("generateWithTools - Mistral backend (real API)", () => {
+  it.skipIf(!hasMistral)("calls get_weather then answers", async () => {
+    await realWeatherCheck(mistral({ model: "mistral-small-latest" }));
+  }, 30_000);
 });

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,0 +1,207 @@
+import { describe, it, expect, vi } from "vitest";
+import { z } from "zod";
+import { generateWithTools } from "../src/core/tools.js";
+import { openai } from "../src/backends/openai.js";
+import { groq } from "../src/backends/groq.js";
+import { anthropic } from "../src/backends/anthropic.js";
+import { ollama } from "../src/backends/ollama.js";
+import { MaxToolTurnsExceededError, ToolExecutionError } from "../src/types.js";
+import type { ShapecraftModel, ToolCallResponse, ToolDefinition } from "../src/types.js";
+
+/** Scripted tool-calling model: one `ToolCallResponse` per `toolCall()` call, in order. `extractResult` backs the final `generate()` extraction pass. */
+function mockToolModel(toolCallScript: ToolCallResponse[], extractResult: unknown): ShapecraftModel {
+  let call = 0;
+  return {
+    id: "mock:tools",
+    guaranteeLevel: "constrained",
+    async generate<T>(): Promise<T> {
+      return extractResult as T;
+    },
+    async toolCall(): Promise<ToolCallResponse> {
+      const reply = toolCallScript[call];
+      call++;
+      if (!reply) throw new Error("mock exhausted: no scripted reply for this turn");
+      return reply;
+    },
+  };
+}
+
+const WeatherSchema = z.object({ city: z.string() });
+const AnswerSchema = z.object({ summary: z.string() });
+
+describe("generateWithTools", () => {
+  it("calls a requested tool with validated args, feeds the result back, then extracts the final answer", async () => {
+    const handler = vi.fn(async ({ city }: { city: string }) => ({ tempC: 22, city }));
+    const getWeather: ToolDefinition = { name: "get_weather", parameters: WeatherSchema, handler: handler as ToolDefinition["handler"] };
+
+    const model = mockToolModel(
+      [{ toolCalls: [{ id: "call_1", name: "get_weather", args: { city: "Lisbon" } }] }, { content: "It's 22C and sunny in Lisbon." }],
+      { summary: "sunny, 22C in Lisbon" }
+    );
+
+    const result = await generateWithTools(model, [getWeather], AnswerSchema, "What's the weather in Lisbon?");
+
+    expect(handler).toHaveBeenCalledWith({ city: "Lisbon" });
+    expect(result.data).toEqual({ summary: "sunny, 22C in Lisbon" });
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0]).toMatchObject({ type: "tool-call", result: { tempC: 22, city: "Lisbon" } });
+  });
+
+  it("executes multiple tool calls returned in a single turn, in order", async () => {
+    const calls: string[] = [];
+    const getWeather: ToolDefinition = {
+      name: "get_weather",
+      parameters: WeatherSchema,
+      handler: (async ({ city }: { city: string }) => {
+        calls.push(city);
+        return { city };
+      }) as ToolDefinition["handler"],
+    };
+
+    const model = mockToolModel(
+      [
+        {
+          toolCalls: [
+            { id: "call_1", name: "get_weather", args: { city: "Lisbon" } },
+            { id: "call_2", name: "get_weather", args: { city: "Porto" } },
+          ],
+        },
+        { content: "Both cities checked." },
+      ],
+      { summary: "done" }
+    );
+
+    const result = await generateWithTools(model, [getWeather], AnswerSchema, "Compare Lisbon and Porto weather.");
+
+    expect(calls).toEqual(["Lisbon", "Porto"]);
+    expect(result.toolCalls).toHaveLength(2);
+  });
+
+  it("a tool call with args that fail its own parameters schema never reaches the handler", async () => {
+    const handler = vi.fn();
+    const getWeather: ToolDefinition = { name: "get_weather", parameters: WeatherSchema, handler };
+
+    // First turn: model sends args missing the required "city" field. Second turn: model gives up and answers.
+    const model = mockToolModel(
+      [{ toolCalls: [{ id: "call_1", name: "get_weather", args: {} }] }, { content: "I couldn't get the weather." }],
+      { summary: "no data" }
+    );
+
+    const result = await generateWithTools(model, [getWeather], AnswerSchema, "What's the weather?");
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.toolCalls).toHaveLength(1);
+    expect(result.toolCalls[0].type).toBe("tool-error");
+  });
+
+  it("an unknown tool name never reaches any handler", async () => {
+    const handler = vi.fn();
+    const getWeather: ToolDefinition = { name: "get_weather", parameters: WeatherSchema, handler };
+
+    const model = mockToolModel(
+      [{ toolCalls: [{ id: "call_1", name: "get_stock_price", args: { symbol: "ACME" } }] }, { content: "done" }],
+      { summary: "done" }
+    );
+
+    const result = await generateWithTools(model, [getWeather], AnswerSchema, "irrelevant");
+
+    expect(handler).not.toHaveBeenCalled();
+    expect(result.toolCalls[0]).toMatchObject({ type: "tool-error" });
+  });
+
+  it("a tool handler throwing aborts immediately with ToolExecutionError, not retried", async () => {
+    const getWeather: ToolDefinition = {
+      name: "get_weather",
+      parameters: WeatherSchema,
+      handler: (async () => {
+        throw new Error("upstream API down");
+      }) as ToolDefinition["handler"],
+    };
+
+    const model = mockToolModel([{ toolCalls: [{ id: "call_1", name: "get_weather", args: { city: "Lisbon" } }] }], { summary: "unreachable" });
+
+    await expect(generateWithTools(model, [getWeather], AnswerSchema, "weather?")).rejects.toBeInstanceOf(ToolExecutionError);
+  });
+
+  it("throws MaxToolTurnsExceededError when the model never stops requesting tools", async () => {
+    const getWeather: ToolDefinition = {
+      name: "get_weather",
+      parameters: WeatherSchema,
+      handler: (async ({ city }: { city: string }) => ({ city })) as ToolDefinition["handler"],
+    };
+
+    const script: ToolCallResponse[] = Array.from({ length: 5 }, () => ({
+      toolCalls: [{ id: "call_x", name: "get_weather", args: { city: "Lisbon" } }],
+    }));
+    const model = mockToolModel(script, { summary: "unreachable" });
+
+    await expect(generateWithTools(model, [getWeather], AnswerSchema, "weather?", { maxTurns: 3 })).rejects.toBeInstanceOf(
+      MaxToolTurnsExceededError
+    );
+  });
+
+  it("a model without toolCall() throws a clear error instead of silently failing", async () => {
+    const model: ShapecraftModel = {
+      id: "mock:no-tools",
+      guaranteeLevel: "constrained",
+      async generate<T>(): Promise<T> {
+        return {} as T;
+      },
+    };
+    const getWeather: ToolDefinition = { name: "get_weather", parameters: WeatherSchema, handler: async () => ({}) };
+
+    await expect(generateWithTools(model, [getWeather], AnswerSchema, "weather?")).rejects.toThrow(/does not support tool calling/);
+  });
+});
+
+// --- Real API - one tool round-trip per backend, skipped when key not in .env ---
+
+const hasOpenAI = !!process.env.OPENAI_API_KEY;
+const hasGroq = !!process.env.GROQ_API_KEY;
+const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
+const hasOllama = !!process.env.OLLAMA_MODEL;
+
+const getWeatherTool: ToolDefinition = {
+  name: "get_weather",
+  description: "Get current weather for a city",
+  parameters: z.object({ city: z.string() }),
+  handler: (async ({ city }: { city: string }) => ({ city, tempC: 22, condition: "sunny" })) as ToolDefinition["handler"],
+};
+
+async function realWeatherCheck(model: ShapecraftModel) {
+  const result = await generateWithTools(
+    model,
+    [getWeatherTool],
+    z.object({ city: z.string(), condition: z.string() }),
+    "What's the weather in Lisbon? Use the get_weather tool, then summarize."
+  );
+  expect(result.toolCalls.length).toBeGreaterThan(0);
+  expect(result.data).toMatchObject({ city: expect.any(String), condition: expect.any(String) });
+  console.log("[real] tool-calling result:", result.data, "trace:", result.toolCalls);
+}
+
+describe("generateWithTools - OpenAI backend (real API)", () => {
+  it.skipIf(!hasOpenAI)("calls get_weather then answers", async () => {
+    await realWeatherCheck(openai({ model: "gpt-4o-mini" }));
+  }, 30_000);
+});
+
+describe("generateWithTools - Groq backend (real API)", () => {
+  it.skipIf(!hasGroq)("calls get_weather then answers", async () => {
+    await realWeatherCheck(groq({ model: "llama-3.3-70b-versatile" }));
+  }, 30_000);
+});
+
+describe("generateWithTools - Anthropic backend (real API)", () => {
+  it.skipIf(!hasAnthropic)("calls get_weather then answers", async () => {
+    await realWeatherCheck(anthropic({ model: "claude-haiku-4-5-20251001" }));
+  }, 30_000);
+});
+
+describe("generateWithTools - Ollama backend (real API)", () => {
+  // Two turns against a CPU-bound local model can each take ~180s - generous
+  // timeout here is about slow local hardware, not the implementation.
+  it.skipIf(!hasOllama)("calls get_weather then answers", async () => {
+    await realWeatherCheck(ollama({ model: process.env.OLLAMA_MODEL ?? "gemma4:e2b", timeoutMs: 300_000 }));
+  }, 480_000);
+});

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { z } from "zod";
 import { generateWithTools } from "../src/core/tools.js";
 import { openai } from "../src/backends/openai.js";
@@ -6,8 +6,9 @@ import { groq } from "../src/backends/groq.js";
 import { anthropic } from "../src/backends/anthropic.js";
 import { ollama } from "../src/backends/ollama.js";
 import { mistral } from "../src/backends/mistral.js";
+import { gemini } from "../src/backends/gemini.js";
 import { MaxToolTurnsExceededError, ToolExecutionError } from "../src/types.js";
-import type { ShapecraftModel, ToolCallResponse, ToolDefinition } from "../src/types.js";
+import type { ChatMessage, ShapecraftModel, ToolCallResponse, ToolDefinition } from "../src/types.js";
 
 /** Scripted tool-calling model: one `ToolCallResponse` per `toolCall()` call, in order. `extractResult` backs the final `generate()` extraction pass. */
 function mockToolModel(toolCallScript: ToolCallResponse[], extractResult: unknown): ShapecraftModel {
@@ -162,6 +163,7 @@ const hasGroq = !!process.env.GROQ_API_KEY;
 const hasAnthropic = !!process.env.ANTHROPIC_API_KEY;
 const hasOllama = !!process.env.OLLAMA_MODEL;
 const hasMistral = !!process.env.MISTRAL_API_KEY;
+const hasGemini = !!process.env.GEMINI_API_KEY;
 
 const getWeatherTool: ToolDefinition = {
   name: "get_weather",
@@ -216,4 +218,131 @@ describe("generateWithTools - Mistral backend (real API)", () => {
   it.skipIf(!hasMistral)("calls get_weather then answers", async () => {
     await realWeatherCheck(mistral({ model: "mistral-small-latest" }));
   }, 30_000);
+});
+
+// The live counterpart to the stubbed shape assertions below: gemini() is the
+// only backend whose tool turn is built from functionCall/functionResponse
+// Parts, so it is worth exercising against the real API, not just a stub.
+describe("generateWithTools - Gemini backend (real API)", () => {
+  it.skipIf(!hasGemini)("calls get_weather then answers", async () => {
+    await realWeatherCheck(gemini({ model: "gemini-flash-latest" }));
+  }, 60_000);
+});
+
+// gemini() is the one backend that can't reuse openAiCompatibleToolCall() - it
+// has to rebuild the transcript as functionCall/functionResponse Parts. That
+// conversion is the part most likely to break and can't be reached by any live
+// test while the key is quota-blocked, so it is asserted directly against a
+// stubbed @google/genai client.
+describe("gemini() toolCall - request shape", () => {
+  afterEach(() => vi.resetModules());
+
+  async function captureGeminiRequest(scriptedResponse: Record<string, unknown>, messages: ChatMessage[]) {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let captured: any;
+    vi.doMock("@google/genai", () => ({
+      GoogleGenAI: class {
+        models = {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          generateContent: async (req: any) => {
+            captured = req;
+            return scriptedResponse;
+          },
+        };
+      },
+    }));
+
+    const { gemini } = await import("../src/backends/gemini.js");
+    const model = gemini({ model: "gemini-flash-latest", apiKey: "test-key" });
+    const reply = await model.toolCall!(messages, [getWeatherTool], "be terse");
+    return { captured, reply };
+  }
+
+  it("sends parametersJsonSchema (plain JSON Schema), not Gemini's Type-enum shape", async () => {
+    const { captured } = await captureGeminiRequest({ text: "done", functionCalls: undefined }, [{ role: "user", content: "weather in Lisbon?" }]);
+
+    const decl = captured.config.tools[0].functionDeclarations[0];
+    expect(decl.name).toBe("get_weather");
+    expect(decl.parametersJsonSchema).toMatchObject({ type: "object", properties: { city: { type: "string" } } });
+    // `parameters` is mutually exclusive with parametersJsonSchema in the SDK.
+    expect(decl.parameters).toBeUndefined();
+    expect(captured.config.systemInstruction).toBe("be terse");
+  });
+
+  it("synthesizes an id when Gemini omits one, since generateWithTools correlates by it", async () => {
+    const { reply } = await captureGeminiRequest({ text: "", functionCalls: [{ name: "get_weather", args: { city: "Lisbon" } }] }, [
+      { role: "user", content: "weather in Lisbon?" },
+    ]);
+
+    expect(reply.toolCalls).toHaveLength(1);
+    expect(reply.toolCalls![0].id).toBeTruthy();
+    expect(reply.toolCalls![0]).toMatchObject({ name: "get_weather", args: { city: "Lisbon" } });
+  });
+
+  it("rebuilds a tool result as a functionResponse Part carrying the function name", async () => {
+    const { captured } = await captureGeminiRequest({ text: "18C", functionCalls: undefined }, [
+      { role: "user", content: "weather in Lisbon?" },
+      { role: "assistant", content: "", toolCalls: [{ id: "call-1", name: "get_weather", args: { city: "Lisbon" } }] },
+      { role: "tool", content: JSON.stringify({ tempC: 18 }), toolCallId: "call-1" },
+    ]);
+
+    expect(captured.contents[1]).toEqual({ role: "model", parts: [{ functionCall: { name: "get_weather", args: { city: "Lisbon" } } }] });
+    // The name is recovered from the assistant turn - a "tool" ChatMessage only
+    // carries toolCallId, but Gemini's functionResponse Part requires the name.
+    expect(captured.contents[2]).toEqual({ role: "user", parts: [{ functionResponse: { name: "get_weather", response: { tempC: 18 } } }] });
+  });
+
+  // Regression: Gemini 400s with "Function call is missing a thought_signature"
+  // if a replayed functionCall Part loses the opaque token it came back with.
+  // The signature has no home on the shared ToolCall type, so the backend keeps
+  // it per instance and reattaches it on the next turn.
+  it("round-trips thoughtSignature back onto the replayed functionCall Part", async () => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const seen: any[] = [];
+    vi.doMock("@google/genai", () => ({
+      GoogleGenAI: class {
+        models = {
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          generateContent: async (req: any) => {
+            seen.push(req);
+            if (seen.length === 1) {
+              return {
+                text: "",
+                candidates: [
+                  { content: { parts: [{ functionCall: { id: "fc-1", name: "get_weather", args: { city: "Lisbon" } }, thoughtSignature: "SIG-ABC" }] } },
+                ],
+              };
+            }
+            return { text: "18C in Lisbon", candidates: [{ content: { parts: [{ text: "18C in Lisbon" }] } }] };
+          },
+        };
+      },
+    }));
+
+    const { gemini } = await import("../src/backends/gemini.js");
+    const model = gemini({ model: "gemini-flash-latest", apiKey: "test-key" });
+
+    const first = await model.toolCall!([{ role: "user", content: "weather?" }], [getWeatherTool]);
+    expect(first.toolCalls![0].id).toBe("fc-1");
+
+    await model.toolCall!(
+      [
+        { role: "user", content: "weather?" },
+        { role: "assistant", content: "", toolCalls: first.toolCalls },
+        { role: "tool", content: JSON.stringify({ tempC: 18 }), toolCallId: "fc-1" },
+      ],
+      [getWeatherTool]
+    );
+
+    expect(seen[1].contents[1].parts[0].thoughtSignature).toBe("SIG-ABC");
+  });
+
+  it("wraps a non-object tool result, which Gemini's response field rejects", async () => {
+    const { captured } = await captureGeminiRequest({ text: "ok", functionCalls: undefined }, [
+      { role: "assistant", content: "", toolCalls: [{ id: "call-1", name: "get_weather", args: {} }] },
+      { role: "tool", content: JSON.stringify([1, 2, 3]), toolCallId: "call-1" },
+    ]);
+
+    expect(captured.contents[1].parts[0].functionResponse.response).toEqual({ result: [1, 2, 3] });
+  });
 });


### PR DESCRIPTION
## Summary
- Adds `generateWithTools(model, tools, schema, prompt, options?)`: runs the model's native `toolCall()` turn against your tool definitions, executes requested tools locally (validating each call's arguments against that tool's `parameters` schema first), feeds results back, and repeats until the model stops asking for tools. The final answer goes through an ordinary `generate()` call over the transcript, so the structured-output guarantee is identical to a standalone `generate()`.
- `toolCall()` is now implemented on every backend except `llamaCpp()` (local GGUF inference exposes no tools API): `openai()`, `groq()`, `fireworks()`, `mistral()`, `openRouter()`, `deepseek()` share one `openAiCompatibleToolCall()` (identical OpenAI wire format); `anthropic()`, `ollama()`, and `gemini()` each have their own native implementation. `ModelCapabilities.toolCalling` reports this per backend.
- `gemini()` needed its own path: `@google/genai` models a tool turn as `functionCall`/`functionResponse` Parts rather than OpenAI's flat `tool_calls` array, and requires reattaching an opaque `thoughtSignature` token on replayed calls (kept per model instance, since it has no home on the shared `ToolCall` type).
- Error handling: a bad tool call (unknown name, or arguments failing the tool's schema) is fed back to the model as a `tool` error message so it can retry; a handler that throws aborts immediately with `ToolExecutionError` (not recoverable by re-prompting). Exceeding `maxTurns` (default 10) throws `MaxToolTurnsExceededError`.
- Fixed along the way: `llamaCpp()` was the only backend with no `capabilities` object at all (now reports `streaming: false`/`toolCalling: false` explicitly); `toJsonSchema()` now strips `$schema` on the Zod v4 native path too, not just the `zod-to-json-schema` fallback.
- Version bump to 2.8.0 (next minor after `agentic-support`'s 2.7.0).

Live-verified against Groq, Anthropic, Mistral, and Gemini. `fireworks()`, `openRouter()`, and `deepseek()` take the identical OpenAI-compatible code path but had no usable credentials to test against at write time.

## Test plan
- [x] `ShapecraftModel.capabilities` coverage for `toolCalling`/`skillDispatch` across all 10 backends, including an invariant guard (`capabilities.toolCalling` must match whether `toolCall()` actually exists)
- [x] Wrong-format input and unrelated-prompt-against-schema cases covered for `generateWithTools()`
- [x] Clean `npm run build` (tsup + `tsc --emitDeclarationOnly`)
